### PR TITLE
Feature #150920876 – Experiment design table assays should appear in multiple contrasts

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/Experiment.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/Experiment.java
@@ -222,6 +222,6 @@ public abstract class Experiment<R extends ReportsGeneExpression> implements Ser
         return Objects.hashCode(accession);
     }
 
-    @Nullable
-    protected abstract JsonObject propertiesForAssay(@NotNull String runOrAssay);
+    @NotNull
+    protected abstract ImmutableList<JsonObject> propertiesForAssay(@NotNull String runOrAssay);
 }

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/baseline/BaselineExperiment.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/baseline/BaselineExperiment.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.model.experiment.baseline;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -67,12 +68,12 @@ public class BaselineExperiment extends Experiment<AssayGroup> {
 
     @Override
     @NotNull
-    protected JsonObject propertiesForAssay(@NotNull String runOrAssay) {
+    protected ImmutableList<JsonObject> propertiesForAssay(@NotNull String runOrAssay) {
         JsonObject result = new JsonObject();
         result.addProperty(
                 "analysed",
                 getDataColumnDescriptors().stream()
                         .anyMatch(assayGroup -> assayGroup.getAssayIds().contains(runOrAssay)));
-        return result;
+        return ImmutableList.of(result);
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/differential/DifferentialExperiment.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/differential/DifferentialExperiment.java
@@ -2,6 +2,8 @@ package uk.ac.ebi.atlas.model.experiment.differential;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
@@ -84,32 +86,44 @@ public class DifferentialExperiment extends Experiment<Contrast> {
 
     @Override
     @NotNull
-    protected JsonObject propertiesForAssay(@NotNull String runOrAssay) {
-        ImmutableList<Pair<String, String>> qualifiedContrasts =
-                Stream.concat(
-                        getDataColumnDescriptors().stream()
-                                .filter(contrast ->
-                                        contrast.getReferenceAssayGroup().getAssayIds().contains(runOrAssay))
-                                .map(contrast -> Pair.of(contrast.getDisplayName(), "reference")),
-                        getDataColumnDescriptors().stream()
-                                .filter(contrast ->
-                                        contrast.getTestAssayGroup().getAssayIds().contains(runOrAssay))
-                                .map(contrast -> Pair.of(contrast.getDisplayName(), "test")))
+    protected ImmutableList<JsonObject> propertiesForAssay(@NotNull String runOrAssay) {
+        var contrastsWhereAssayIsInReferenceAssayGroup =
+                getDataColumnDescriptors().stream()
+                        .filter(contrast -> contrast.getReferenceAssayGroup().getAssayIds().contains(runOrAssay))
+                        .collect(toImmutableList());
+        var contrastsWhereAssayIsInTestAssayGroup =
+                getDataColumnDescriptors().stream()
+                        .filter(contrast -> contrast.getTestAssayGroup().getAssayIds().contains(runOrAssay))
+                        .collect(toImmutableList());
+
+        // Assay is not in either test or reference assay groups
+        if (contrastsWhereAssayIsInReferenceAssayGroup.isEmpty() && contrastsWhereAssayIsInTestAssayGroup.isEmpty()) {
+            var jsonObject = new JsonObject();
+            jsonObject.addProperty("contrastName", "none");
+            jsonObject.addProperty("referenceOrTest", "");
+            return ImmutableList.of(jsonObject);
+        }
+
+        return Streams.concat(
+                contrastsWhereAssayIsInReferenceAssayGroup.stream()
+                        .map(DifferentialExperiment::referenceContrastToJson),
+                contrastsWhereAssayIsInTestAssayGroup.stream()
+                        .map(DifferentialExperiment::testContrastToJson))
                 .collect(toImmutableList());
-
-
-        JsonObject result = new JsonObject();
-        result.addProperty(
-                "contrastName",
-                qualifiedContrasts.isEmpty() ?
-                        "None" :
-                        qualifiedContrasts.stream().map(Pair::getLeft).collect(joining(" / ")));
-        result.addProperty(
-                "referenceOrTest",
-                qualifiedContrasts.isEmpty() ?
-                        "" :
-                        qualifiedContrasts.stream().map(Pair::getRight).collect(joining(" / ")));
-
-        return result;
     }
+
+    static private JsonObject testContrastToJson(Contrast contrast) {
+        var jsonObject = new JsonObject();
+        jsonObject.addProperty("contrastName", contrast.getDisplayName());
+        jsonObject.addProperty("referenceOrTest", "test");
+        return jsonObject;
+    }
+
+    static private JsonObject referenceContrastToJson(Contrast contrast) {
+        var jsonObject = new JsonObject();
+        jsonObject.addProperty("contrastName", contrast.getDisplayName());
+        jsonObject.addProperty("referenceOrTest", "reference");
+        return jsonObject;
+    }
+
 }

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/singlecell/SingleCellBaselineExperiment.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/singlecell/SingleCellBaselineExperiment.java
@@ -3,7 +3,6 @@ package uk.ac.ebi.atlas.model.experiment.singlecell;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDisplayDefaults;
@@ -46,8 +45,8 @@ public class SingleCellBaselineExperiment extends Experiment<Cell> {
     }
 
     @Override
-    @Nullable
-    protected JsonObject propertiesForAssay(@NotNull String runOrAssay) {
-        return null;
+    @NotNull
+    protected ImmutableList<JsonObject> propertiesForAssay(@NotNull String runOrAssay) {
+        return ImmutableList.of();
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTableTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTableTest.java
@@ -1,0 +1,60 @@
+package uk.ac.ebi.atlas.model.experiment;
+
+import com.google.common.collect.ImmutableSortedSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
+
+import java.util.stream.StreamSupport;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExperimentDesignTableTest {
+    @Mock
+    ExperimentDesign experimentDesignMock;
+
+    private DifferentialExperiment experiment;
+
+    private ExperimentDesignTable subject;
+
+    @BeforeEach
+    void setUp() {
+        experiment =
+                new ExperimentBuilder.DifferentialExperimentBuilder()
+                        .withExperimentDesign(experimentDesignMock)
+                        .build();
+
+        when(experimentDesignMock.getAllRunOrAssay())
+                .thenReturn(ImmutableSortedSet.copyOf(experiment.getAnalysedAssays()));
+
+
+        subject = new ExperimentDesignTable(experiment);
+    }
+
+    @Test
+    void assayIdsAppearInAllContrastsThatContainTheirAssayGroup() {
+        var assayIdsInMultipleContrasts =
+                experiment.getAnalysedAssays().stream()
+                        .filter(assayId ->
+                            experiment.getDataColumnDescriptors().stream()
+                                    .filter(contrast -> contrast.getAssayIds().contains(assayId))
+                                    .count() > 1)
+                        .collect(toImmutableSet());
+
+        var result = subject.asJson();
+
+        for (var assayId : assayIdsInMultipleContrasts) {
+            assertThat(
+                    StreamSupport.stream(result.get("data").getAsJsonArray().spliterator(), false)
+                        .filter(jsonElement -> jsonElement.getAsJsonObject().get("values").getAsJsonArray().get(0).getAsString().equals(assayId))
+                        .count() > 1)
+                    .isTrue();
+        }
+    }
+}

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentTest.java
@@ -79,9 +79,9 @@ class ExperimentTest {
         }
 
         @Override
-        @Nullable
-        protected JsonObject propertiesForAssay(@NotNull String runOrAssay) {
-            return null;
+        @NotNull
+        protected ImmutableList<JsonObject> propertiesForAssay(@NotNull String runOrAssay) {
+            return ImmutableList.of();
         }
     }
 

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/baseline/BaselineExperimentTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/baseline/BaselineExperimentTest.java
@@ -66,7 +66,7 @@ class BaselineExperimentTest {
         BaselineExperiment subject = new BaselineExperimentBuilder().build();
 
         ctx = JsonPath.parse(subject.propertiesForAssay(randomAlphabetic(10)).toString());
-        assertThat(ctx.<Boolean>read("$.analysed")).isFalse();
+        assertThat(ctx.<List<Boolean>>read("$[*].analysed")).containsOnly(false);
 
         ImmutableList<String> experimentAssayIds =
                 subject.getDataColumnDescriptors().stream()
@@ -75,6 +75,6 @@ class BaselineExperimentTest {
         String anyExperimentAssayId = experimentAssayIds.get(RNG.nextInt(experimentAssayIds.size()));
 
         ctx = JsonPath.parse(subject.propertiesForAssay(anyExperimentAssayId).toString());
-        assertThat(ctx.<Boolean>read("$.analysed")).isTrue();
+        assertThat(ctx.<List<Boolean>>read("$[*].analysed")).containsOnly(true);
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/differential/DifferentialExperimentTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/differential/DifferentialExperimentTest.java
@@ -65,21 +65,21 @@ class DifferentialExperimentTest {
         ReadContext referenceCtx = JsonPath.parse(subject.propertiesForAssay(referenceAssayId).toString());
         assertThat(contrasts)
                 .anyMatch(contrast ->
-                        referenceCtx.<String>read("$.contrastName").contains(contrast.getDisplayName()) &&
-                        referenceCtx.<String>read("$.referenceOrTest").contains("reference"));
+                        referenceCtx.<List<String>>read("$[*].contrastName").contains(contrast.getDisplayName()) &&
+                        referenceCtx.<List<String>>read("$[*].referenceOrTest").contains("reference"));
 
 
         ReadContext testCtx = JsonPath.parse(subject.propertiesForAssay(testAssayId).toString());
         assertThat(contrasts)
                 .anyMatch(contrast ->
-                        testCtx.<String>read("$.contrastName").contains(contrast.getDisplayName()) &&
-                        testCtx.<String>read("$.referenceOrTest").contains("test"));
+                        testCtx.<List<String>>read("$[*].contrastName").contains(contrast.getDisplayName()) &&
+                        testCtx.<List<String>>read("$[*].referenceOrTest").contains("test"));
 
         ReadContext fooCtx = JsonPath.parse(subject.propertiesForAssay(randomAlphabetic(10)).toString());
-        assertThat(fooCtx.<String>read("$.contrastName"))
-                .isEqualTo("None");
-        assertThat(fooCtx.<String>read("$.referenceOrTest"))
-                .isEqualTo("");
+        assertThat(fooCtx.<List<String>>read("$[*].contrastName"))
+                .containsOnly("none");
+        assertThat(fooCtx.<List<String>>read("$[*].referenceOrTest"))
+                .containsOnly("");
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/singlecell/SingleCellBaselineExperimentTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/singlecell/SingleCellBaselineExperimentTest.java
@@ -9,13 +9,13 @@ import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateBlankString;
 
 class SingleCellBaselineExperimentTest {
     @Test
-    void propertiesForAssayAlwaysReturnsNull() {
+    void propertiesForAssayAreAlwaysEmpty() {
         SingleCellBaselineExperiment subject = new SingleCellBaselineExperimentBuilder().build();
 
         assertThat(
                 subject.propertiesForAssay(subject.getAnalysedAssays().iterator().next()))
                 .isEqualTo(subject.propertiesForAssay(randomAlphanumeric(10)))
                 .isEqualTo(subject.propertiesForAssay(generateBlankString()))
-                .isNull();
+                .isEmpty();
     }
 }


### PR DESCRIPTION
An old bug that I thought I had solved, but it turns out that the problem was a bit more convoluted.

Since `ExperimentDesignTable::dataRow` iterates over assays, only the first contrast where it appeared was added to the table. To add as many rows as pairs of contrast/assay, `propertiesForAssay` needs to be able to return more than one `JsonObject`.

I’m a bit uncertain about the tests. In other places where we test JSON objects, we serialise them as strings and then use JsonPath (e.g. the fixed tests in the experiment classes). Is the test in `ExperimentDesignTableTest` any better, worse, the same?