### PR TITLE
Feature #164761898 – ArrayExpress discovery service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     implementation 'org.springframework:spring-jdbc:5.1.5.RELEASE'
     implementation 'org.springframework:spring-web:5.1.5.RELEASE'
     implementation 'org.springframework:spring-webmvc:5.1.5.RELEASE'
+    implementation 'org.springframework:spring-webflux:5.1.5.RELEASE'
+
+    implementation 'io.projectreactor.netty:reactor-netty:0.8.6.RELEASE'
+    implementation 'org.reactivestreams:reactive-streams:1.0.2'
 
     implementation 'com.google.guava:guava:27.1-jre'
     
@@ -85,7 +89,7 @@ dependencies {
 
     // Nasty bug in HttpClient 4.5.3 (bundled with Solr)
     // https://issues.apache.org/jira/browse/HTTPCLIENT-1831
-    implementation 'org.apache.httpcomponents:httpclient:4.5.5'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.8'
     implementation ('org.apache.solr:solr-core:7.1.0') {
         exclude module: 'httpclient'
     }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/LinkToArrayExpress.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/LinkToArrayExpress.java
@@ -39,7 +39,6 @@ public abstract class LinkToArrayExpress<E extends Experiment> extends Externall
                     .pathSegment("{0}")
                     .path("/");
     private static final WebClient webClient = WebClient.create();
-    private static final WebClient arrayExpressWebClient = WebClient.create();
 
     private static final Function<Experiment, String> formatLabelToExperiment =
             e -> MessageFormat.format("ArrayExpress: experiment {0}", e.getAccession());

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/LinkToArrayExpress.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/LinkToArrayExpress.java
@@ -1,30 +1,50 @@
 package uk.ac.ebi.atlas.experimentpage;
 
-import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import org.springframework.web.util.UriBuilder;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
 
-import javax.inject.Named;
+import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.util.Collections.singleton;
 
 public abstract class LinkToArrayExpress<E extends Experiment> extends ExternallyAvailableContent.Supplier<E> {
+    // You’ll get a 302 if the last slash is missing!
+    private static final UriBuilder EXPERIMENTS_URI_BUILDER =
+            new DefaultUriBuilderFactory().builder()
+                    .scheme("https")
+                    .host("www.ebi.ac.uk")
+                    .pathSegment("arrayexpress")
+                    .pathSegment("experiments")
+                    .pathSegment("{0}")
+                    .path("/");
+    private static final UriBuilder ARRAYS_URI_BUILDER =
+            new DefaultUriBuilderFactory().builder()
+                    .scheme("https")
+                    .host("www.ebi.ac.uk")
+                    .pathSegment("arrayexpress")
+                    .pathSegment("arrays")
+                    .pathSegment("{0}")
+                    .path("/");
+    private static final WebClient webClient = WebClient.create();
+    private static final WebClient arrayExpressWebClient = WebClient.create();
+
     private static final Function<Experiment, String> formatLabelToExperiment =
             e -> MessageFormat.format("ArrayExpress: experiment {0}", e.getAccession());
     private static final Function<String, String> formatLabelToArray =
             arrayAccession -> MessageFormat.format("ArrayExpress: array design {0}", arrayAccession);
-
-    private static final Function<Experiment, String> formatLinkToExperiment =
-            e -> MessageFormat.format("https://www.ebi.ac.uk/arrayexpress/experiments/{0}", e.getAccession());
-    private static final Function<String, String> formatLinkToArray =
-            arrayAccession -> MessageFormat.format("https://www.ebi.ac.uk/arrayexpress/arrays/{0}", arrayAccession);
 
     private static final Function<String, ExternallyAvailableContent.Description> createIcon =
             label -> ExternallyAvailableContent.Description.create("icon-ae", label);
@@ -41,42 +61,52 @@ public abstract class LinkToArrayExpress<E extends Experiment> extends Externall
 
     @Override
     public Collection<ExternallyAvailableContent> get(E experiment) {
-        return singleton(
-                new ExternallyAvailableContent(
-                        formatLinkToExperiment.apply(experiment),
-                        createIconForExperiment.apply(experiment)));
+         return Stream.of(experiment.getAccession())
+                 .map(EXPERIMENTS_URI_BUILDER::build)
+                 .filter(LinkToArrayExpress::isUriValid)
+                 .map(uri -> new ExternallyAvailableContent(
+                        uri.toString(),
+                        createIconForExperiment.apply(experiment)))
+                 .collect(toImmutableList());
     }
 
-    @Named
-    public static class ProteomicsBaseline extends LinkToArrayExpress<BaselineExperiment> {
-        // In the future we will source proteomics experiments from PRIDE, and one requirement is that they are not
-        // backported into ArrayExpress. E-PROT-6 is an example experiment from PRIDE not in AE.
-        private static final Collection<String> PROTEOMICS_EXPERIMENTS_S_IN_AE =
-                ImmutableList.of("E-PROT-1", "E-PROT-3", "E-PROT-5");
+    @Component
+    public static class ProteomicsBaseline extends LinkToArrayExpress<BaselineExperiment> {}
 
-        @Override
-        public Collection<ExternallyAvailableContent> get(BaselineExperiment experiment) {
-            return PROTEOMICS_EXPERIMENTS_S_IN_AE.contains(experiment.getAccession()) ?
-                    super.get(experiment) :
-                    ImmutableList.of();
-        }
-    }
-
-    @Named
+    @Component
     public static class RnaSeqBaseline extends LinkToArrayExpress<BaselineExperiment> {}
 
-    @Named
+    @Component
     public static class Differential extends LinkToArrayExpress<DifferentialExperiment> {}
 
-    @Named
+    @Component
     public static class Microarray extends LinkToArrayExpress<MicroarrayExperiment> {
         @Override
         public Collection<ExternallyAvailableContent> get(MicroarrayExperiment experiment) {
-            return experiment.getArrayDesignAccessions().stream()
-                    .map(arrayDesignAccession -> new ExternallyAvailableContent(
-                            formatLinkToArray.apply(arrayDesignAccession),
-                            createIconForArray.apply(arrayDesignAccession)))
+            return Stream.concat(
+                    super.get(experiment).stream(),
+                    experiment.getArrayDesignAccessions().stream()
+                            .parallel()
+                            .map(accession -> Pair.of(ARRAYS_URI_BUILDER.build(accession), accession))
+                            .filter(uriAccession -> isUriValid(uriAccession.getLeft()))
+                            .map(uriAccession -> new ExternallyAvailableContent(
+                                    uriAccession.getLeft().toString(),
+                                    createIconForArray.apply(uriAccession.getRight()))))
                     .collect(toImmutableList());
+        }
+    }
+
+    private static boolean isUriValid(@NotNull URI uri) {
+        try {
+            return !webClient
+                    .get()
+                    .uri(uri)
+                    .exchange()
+                    .block()
+                    .statusCode()
+                    .isError();
+        } catch (Exception e) {
+            return false;
         }
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/LinkToArrayExpressTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/LinkToArrayExpressTest.java
@@ -3,10 +3,8 @@ package uk.ac.ebi.atlas.experimentpage;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import uk.ac.ebi.atlas.model.arraydesign.ArrayDesign;
-import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/LinkToArrayExpressTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/LinkToArrayExpressTest.java
@@ -1,0 +1,80 @@
+package uk.ac.ebi.atlas.experimentpage;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.atlas.model.arraydesign.ArrayDesign;
+import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
+import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
+
+class LinkToArrayExpressTest {
+    @Test
+    void emptyLinkIfRnaSeqBaselineExperimentNotOnArrayExpress() {
+        var rnaSeqBaselineExperiment = new ExperimentBuilder.BaselineExperimentBuilder().build();
+        var subject = new LinkToArrayExpress.RnaSeqBaseline();
+
+        assertThat(subject.get(rnaSeqBaselineExperiment)).isEmpty();
+    }
+
+    @Test
+    void emptyLinkIfProteomicsBaselineExperimentNotOnArrayExpress() {
+        var proteomicsBaselineExperiment = new ExperimentBuilder.BaselineExperimentBuilder().build();
+        var subject = new LinkToArrayExpress.ProteomicsBaseline();
+
+        assertThat(subject.get(proteomicsBaselineExperiment)).isEmpty();
+    }
+
+    @Test
+    void emptyLinkIfDifferentialExperimentNotOnArrayExpress() {
+        var differentialExperiment = new ExperimentBuilder.DifferentialExperimentBuilder().build();
+        var subject = new LinkToArrayExpress.Differential();
+
+        assertThat(subject.get(differentialExperiment)).isEmpty();
+    }
+
+    @Test
+    void emptyLinkIfMicroarrayExperimentNotOnArrayExpress() {
+        var microarrayExperiment =
+                new ExperimentBuilder.MicroarrayExperimentBuilder()
+                        // This is what happens when our mock data is too close to real data
+                        .withArrayDesigns(ImmutableList.of(ArrayDesign.create(randomAlphanumeric(10))))
+                        .build();
+        var subject = new LinkToArrayExpress.Microarray();
+
+        assertThat(subject.get(microarrayExperiment)).isEmpty();
+    }
+
+    // Ideally we would pick a microarray experiment using JdbcUtils, but LinkToArrayExpress takes an experiment object
+    // as an argument, and we’d need an experiment trader, which currently are on the parent projects
+    @Test
+    void linkIfMicroarrayExperimentIsOnArrayExpress() {
+        var microarrayExperiment =
+                new ExperimentBuilder.MicroarrayExperimentBuilder()
+                        .withExperimentAccession("E-MEXP-1968")
+                        .withArrayDesigns(ImmutableList.of(ArrayDesign.create("A-AFFY-45")))
+                        .build();
+        var subject = new LinkToArrayExpress.Microarray();
+
+        // We can’t use URI::getPath because the redirect prefix messes it up :/
+        assertThat(subject.get(microarrayExperiment))
+                .anyMatch(externallyAvailableContent ->
+                        externallyAvailableContent.uri.toString().endsWith("/experiments/E-MEXP-1968/"))
+                .anyMatch(externallyAvailableContent ->
+                        externallyAvailableContent.uri.toString().endsWith("/arrays/A-AFFY-45/"))
+                .hasSize(2);
+    }
+
+    @Test
+    void linksToArrayExpressShowInSupplementaryInformationTab() {
+        assertThat(new LinkToArrayExpress.RnaSeqBaseline().contentType())
+                .isEqualTo(new LinkToArrayExpress.ProteomicsBaseline().contentType())
+                .isEqualTo(new LinkToArrayExpress.Differential().contentType())
+                .isEqualTo(new LinkToArrayExpress.Microarray().contentType())
+                .isEqualTo(SUPPLEMENTARY_INFORMATION);
+    }
+
+}

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentBuilder.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentBuilder.java
@@ -33,12 +33,7 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
 import static uk.ac.ebi.atlas.model.experiment.ExperimentType.SINGLE_CELL_RNASEQ_MRNA_BASELINE;
-import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomAssayGroups;
-import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomBiologicalReplicates;
-import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomContrasts;
-import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
-import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomPrideExperimentAccession;
-import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomSpecies;
+import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.*;
 
 // It’s funny how unnecessary the builder was in main and how much it helps to keep tests DRY. If we bring the builder
 // back, I think this design using generics is much better than the previous one.
@@ -89,7 +84,11 @@ public abstract class ExperimentBuilder<R extends ReportsGeneExpression, E exten
     // Only for differential experiments
     ImmutableList<Boolean> cttvPrimaryContrastAnnotations;
     // Only for microarray experiments
-    ImmutableList<ArrayDesign> arrayDesigns;
+    ImmutableList<ArrayDesign> arrayDesigns =
+            IntStream.range(1, 5).boxed()
+                    .map(__ -> generateRandomArrayDesignAccession())
+                    .map(ArrayDesign::create)
+                    .collect(toImmutableList());
 
     private <T> ImmutableList<T> pad(List<T> list, int n, Supplier<T> supplier) {
         if (list.size() >= n) {


### PR DESCRIPTION
In the end, I followed the path of least resistance and added the method to know if an experiment is in ArrayExpress to `LinkToArrayExpress`. I originally thought that having it in the experiment builder, even though it would be somewhat against the priniple of separation of concerns, would be better because the link would be only validated once. However, since the link is only requested via a JSON endpoint when the *Supplementary Information* tab is shown, it doesn’t affect the overall performance of the experiment page.

I decided to go the extra mile and check array designs too.