### PR TITLE
Bugfix #165564862 – Single cell experiment design table is empty

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/analyticsindex/conditions/EfoLookupService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/analyticsindex/conditions/EfoLookupService.java
@@ -24,7 +24,8 @@ import static uk.ac.ebi.atlas.utils.StringUtil.suffixAfterLastSlash;
 @Component
 public class EfoLookupService {
     private static final Logger LOGGER = LoggerFactory.getLogger(EfoLookupService.class);
-    private static final String EFO_OWL_FILE_URL = "https://www.ebi.ac.uk/efo/efo.owl";
+    //private static final String EFO_OWL_FILE_URL = "https://www.ebi.ac.uk/efo/efo.owl";
+    private static final String EFO_OWL_FILE_URL = "https://raw.githubusercontent.com/EBISPOT/efo/v2019-03-18/efo.owl";
 
     private final LazyReference<ImmutableMap<String, EFONode>> idToEFONode =
             new LazyReference<>() {

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/singlecell/SingleCellBaselineExperiment.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/singlecell/SingleCellBaselineExperiment.java
@@ -47,6 +47,13 @@ public class SingleCellBaselineExperiment extends Experiment<Cell> {
     @Override
     @NotNull
     protected ImmutableList<JsonObject> propertiesForAssay(@NotNull String runOrAssay) {
-        return ImmutableList.of();
+        // Currently we’re ignoring on the front-end the analysed property in single cell experiments, but it must be
+        // present for the logic in ExperimentDesignTable to be consistent and display a properly populated table
+        JsonObject result = new JsonObject();
+        result.addProperty(
+                "analysed",
+                getDataColumnDescriptors().stream()
+                        .anyMatch(assayGroup -> assayGroup.getAssayIds().contains(runOrAssay)));
+        return ImmutableList.of(result);
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTableTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTableTest.java
@@ -1,7 +1,6 @@
 package uk.ac.ebi.atlas.model.experiment;
 
 import com.google.common.collect.ImmutableSortedSet;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -19,10 +18,6 @@ class ExperimentDesignTableTest {
     ExperimentDesign experimentDesignMock;
 
     private ExperimentDesignTable subject;
-
-    @BeforeEach
-    void setUp() {
-    }
 
     @Test
     void assayIdsAppearInAllContrastsThatContainTheirAssayGroup() {

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/singlecell/SingleCellBaselineExperimentTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/singlecell/SingleCellBaselineExperimentTest.java
@@ -5,17 +5,22 @@ import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder.SingleCellBaselineExpe
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateBlankString;
 
 class SingleCellBaselineExperimentTest {
+    // The best test name
     @Test
-    void propertiesForAssayAreAlwaysEmpty() {
+    void analysedAssaysAreAnalysed() {
         SingleCellBaselineExperiment subject = new SingleCellBaselineExperimentBuilder().build();
 
-        assertThat(
-                subject.propertiesForAssay(subject.getAnalysedAssays().iterator().next()))
-                .isEqualTo(subject.propertiesForAssay(randomAlphanumeric(10)))
-                .isEqualTo(subject.propertiesForAssay(generateBlankString()))
-                .isEmpty();
+        assertThat(subject.getAnalysedAssays())
+                .allMatch(assayId -> subject.propertiesForAssay(assayId).get(0).get("analysed").getAsBoolean());
+    }
+
+    @Test
+    void nonExistingAssaysAreNotAnalysed() {
+        SingleCellBaselineExperiment subject = new SingleCellBaselineExperimentBuilder().build();
+
+        assertThat(subject.propertiesForAssay(randomAlphanumeric(1, 10)).get(0).get("analysed").getAsBoolean())
+                .isFalse();
     }
 }


### PR DESCRIPTION
After the logic that built the experiment design table was changed to have assays show up in multiple contrasts, single cell experiments need to return at least one property for each assay ID to actually add it to the table. In principle it could be anything, since the experiment page React component is ignoring the `properties` field, but I followed the same logic as other baseline experiments.

Also, I linked to the last and final EFO v2 release until we fix `EfoLookupService` to work properly with EFO v3. Otherwise the builds won’t pass (I committed to `master` and cherry-picked here).