### PR TITLE
Bugfix #165632716 – Random contrasts have duplicate technical replicate IDs

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/testutils/RandomDataTestUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/testutils/RandomDataTestUtils.java
@@ -5,7 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.tuple.ImmutablePair;
+import com.google.common.collect.Streams;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.jetbrains.annotations.NotNull;
 import uk.ac.ebi.atlas.model.experiment.sample.AssayGroup;
@@ -207,14 +207,21 @@ public class RandomDataTestUtils {
             ImmutableSet<String> allIdsGeneratedSoFar =
                     assayGroups.stream()
                             .flatMap(assayGroup ->
-                                    Stream.concat(assayGroup.getAssayIds().stream(), Stream.of(assayGroup.getId())))
+                                    Streams.concat(
+                                            // ID of assays, either a tech. replicate ID or a biological replicate ID
+                                            assayGroup.getAssays().stream().map(BiologicalReplicate::getId),
+                                            // If the assay is a technical replicate, there will be multiple assay IDs
+                                            assayGroup.getAssayIds().stream(),
+                                            // And finally the assay group ID
+                                            Stream.of(assayGroup.getId())))
                             .collect(toImmutableSet());
 
             ImmutableSet<String> newAssayGroupIds =
-                    ImmutableSet.<String>builder()
-                            .addAll(newAssayGroup.getAssayIds())
-                            .add(newAssayGroup.getId())
-                            .build();
+                    Streams.concat(
+                            newAssayGroup.getAssays().stream().map(BiologicalReplicate::getId),
+                            newAssayGroup.getAssayIds().stream(),
+                            Stream.of(newAssayGroup.getId()))
+                    .collect(toImmutableSet());
 
             if (Sets.intersection(allIdsGeneratedSoFar, newAssayGroupIds).isEmpty()) {
                 assayGroups.add(newAssayGroup);

--- a/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTrader.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTrader.java
@@ -11,7 +11,6 @@ import uk.ac.ebi.atlas.experimentimport.ExperimentDto;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
-import uk.ac.ebi.atlas.web.interceptors.TimingInterceptor;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 


### PR DESCRIPTION
I sampled this with repeated tests and it happened once every 1,000 runs; and yet by Murphy’s law in our builds it did way more often!