### PR TITLE
Chore #166333923 – Reduce maxLifetime to 20 seconds

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/configuration/JdbcConfig.java
+++ b/src/main/java/uk/ac/ebi/atlas/configuration/JdbcConfig.java
@@ -27,6 +27,7 @@ public class JdbcConfig {
         hikariConfig = new HikariConfig();
         hikariConfig.setDataSourceClassName("org.postgresql.ds.PGSimpleDataSource");
         hikariConfig.setPoolName(poolName + "Hikari");
+        hikariConfig.setMaxLifetime(20000L);    // EBI policy requires URL requests to be resolved within 30 seconds
 
         Properties dataSourceProperties = new Properties();
         dataSourceProperties.setProperty("url", jdbcUrl);


### PR DESCRIPTION
We saw the app being starved of connections because HikariCP wouldn’t close them before 30 minutes, and the DB was locked when refreshing some materailized views.