### PR TITLE
Bugfix #166430782 – Show build info in `json/build` endpoint

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckService.java
+++ b/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckService.java
@@ -6,21 +6,20 @@ import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDao;
 import uk.ac.ebi.atlas.solr.cloud.admin.SolrCloudAdminProxy;
 
-import java.util.List;
+import java.util.Collection;
 
 @Component
 public class HealthCheckService {
-    private SolrCloudAdminProxy solrCloudAdminProxy;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckService.class);
+    private SolrCloudAdminProxy solrCloudAdminProxy;
 
     public HealthCheckService(SolrCloudAdminProxy solrCloudAdminProxy) {
         this.solrCloudAdminProxy = solrCloudAdminProxy;
     }
 
-    public boolean isSolrUp(List<String> solrCollections, String... solrCollectionsWithAliases) {
+    public boolean isSolrUp(Collection<String> collectionNames, Collection<String> collectionAliases) {
         try {
-            return solrCloudAdminProxy.areCollectionsUp(solrCollections, solrCollectionsWithAliases);
+            return solrCloudAdminProxy.areCollectionsUp(collectionNames, collectionAliases);
         } catch (Exception e) {
             LOGGER.error(e.getMessage());
             return false;

--- a/src/main/java/uk/ac/ebi/atlas/monitoring/HealthChecker.java
+++ b/src/main/java/uk/ac/ebi/atlas/monitoring/HealthChecker.java
@@ -1,0 +1,32 @@
+package uk.ac.ebi.atlas.monitoring;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import uk.ac.ebi.atlas.experimentimport.ExperimentDao;
+
+import java.util.Collection;
+
+public class HealthChecker {
+    private final HealthCheckService healthCheckService;
+    private final ExperimentDao experimentDao;
+    private final ImmutableSet<String> collectionNames;
+    private final ImmutableSet<String> collectionAliases;
+
+    public HealthChecker(HealthCheckService healthCheckService,
+                         ExperimentDao experimentDao,
+                         Collection<String> collectionNames,
+                         Collection<String> collectionAliases) {
+        this.healthCheckService = healthCheckService;
+        this.experimentDao = experimentDao;
+        this.collectionNames = ImmutableSet.copyOf(collectionNames);
+        this.collectionAliases = ImmutableSet.copyOf(collectionAliases);
+    }
+
+    protected ImmutableMap<String, String> getHealthStatus() {
+        return ImmutableMap.of(
+                "solr",
+                healthCheckService.isSolrUp(collectionNames, collectionAliases) ? "UP" : "DOWN",
+                "db",
+                healthCheckService.isDatabaseUp(experimentDao) ? "UP" : "DOWN");
+    }
+}

--- a/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckServiceTest.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.monitoring;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,17 +11,13 @@ import uk.ac.ebi.atlas.experimentimport.ExperimentDao;
 import uk.ac.ebi.atlas.solr.cloud.admin.SolrCloudAdminProxy;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class HealthCheckServiceTest {
-
     @Mock
     private SolrCloudAdminProxy solrCloudAdminProxyMock;
 
@@ -29,8 +26,9 @@ class HealthCheckServiceTest {
 
     private HealthCheckService subject;
 
-    private static final List<String> MOCK_SOLR_COLLECTIONS = Arrays.asList("mockCollection1", "mockCollection2");
-    private static final String MOCK_SOLR_COLLECTION_ALIAS = "mockCollectionAlias";
+    private static final ImmutableSet<String> MOCK_SOLR_COLLECTIONS =
+            ImmutableSet.of("mockCollection1", "mockCollection2");
+    private static final ImmutableSet<String> MOCK_SOLR_COLLECTION_ALIAS = ImmutableSet.of("mockCollectionAlias");
 
     @BeforeEach
     void setUp() {
@@ -39,43 +37,38 @@ class HealthCheckServiceTest {
 
     @Test
     void solrCollectionsAreUp() throws IOException, SolrServerException {
-        when(solrCloudAdminProxyMock.areCollectionsUp(anyList(), any())).thenReturn(true);
-
+        when(solrCloudAdminProxyMock.areCollectionsUp(anyCollection(), anyCollection())).thenReturn(true);
         assertThat(subject.isSolrUp(MOCK_SOLR_COLLECTIONS, MOCK_SOLR_COLLECTION_ALIAS)).isTrue();
     }
 
     @Test
     void solrCollectionsAreDown() throws IOException, SolrServerException {
-        when(solrCloudAdminProxyMock.areCollectionsUp(anyList(), any())).thenReturn(false);
-
+        when(solrCloudAdminProxyMock.areCollectionsUp(anyCollection(), anyCollection())).thenReturn(false);
         assertThat(subject.isSolrUp(MOCK_SOLR_COLLECTIONS, MOCK_SOLR_COLLECTION_ALIAS)).isFalse();
     }
 
     @Test
     void solrThrowsException() throws IOException, SolrServerException {
-        when(solrCloudAdminProxyMock.areCollectionsUp(anyList(), any())).thenThrow(RuntimeException.class);
-
+        when(solrCloudAdminProxyMock.areCollectionsUp(anyCollection(), anyCollection()))
+                .thenThrow(RuntimeException.class);
         assertThat(subject.isSolrUp(MOCK_SOLR_COLLECTIONS, MOCK_SOLR_COLLECTION_ALIAS)).isFalse();
     }
 
     @Test
     void experimentsDatabaseIsUp() {
         when(experimentDaoMock.countExperiments()).thenReturn(9);
-
         assertThat(subject.isDatabaseUp(experimentDaoMock)).isTrue();
     }
 
     @Test
     void noExperimentsInDatabase() {
         when(experimentDaoMock.countExperiments()).thenReturn(0);
-
         assertThat(subject.isDatabaseUp(experimentDaoMock)).isFalse();
     }
 
     @Test
     void experimentDaoThrowsException() {
         when(experimentDaoMock.countExperiments()).thenThrow(RuntimeException.class);
-
         assertThat(subject.isDatabaseUp(experimentDaoMock)).isFalse();
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckerTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckerTest.java
@@ -1,0 +1,56 @@
+package uk.ac.ebi.atlas.monitoring;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.ac.ebi.atlas.experimentimport.ExperimentDao;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HealthCheckerTest {
+    private final static Random RNG = ThreadLocalRandom.current();
+    private final static ImmutableSet<String> collectionNames = ImmutableSet.of("collectionName1");
+    private final static ImmutableSet<String> collectionAliases = ImmutableSet.of("collectionAlias1");
+
+    @Mock
+    private HealthCheckService healthCheckServiceMock;
+
+    @Mock
+    private ExperimentDao experimentDaoMock;
+
+    private HealthChecker subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new HealthChecker(healthCheckServiceMock, experimentDaoMock, collectionNames, collectionAliases);
+    }
+
+    @Test
+    void resultReflectsServicesStatus() {
+        var isSolrUp = RNG.nextBoolean();
+        when(healthCheckServiceMock.isSolrUp(any(), any())).thenReturn(isSolrUp);
+
+        var isDbUp = RNG.nextBoolean();
+        when(healthCheckServiceMock.isDatabaseUp(any())).thenReturn(isDbUp);
+
+        assertThat(subject.getHealthStatus())
+                .containsOnly(
+                        createMapEntry("solr", isSolrUp ? "UP" : "DOWN"),
+                        createMapEntry("db", isDbUp ? "UP" : "DOWN"));
+    }
+
+    private static <K, V> Map.Entry<K, V> createMapEntry(K key, V value) {
+        return ImmutableMap.of(key, value).entrySet().iterator().next();
+    }
+}

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxyIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/admin/SolrCloudAdminProxyIT.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.solr.cloud.admin;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,8 +10,6 @@ import uk.ac.ebi.atlas.configuration.TestConfig;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -23,27 +22,30 @@ class SolrCloudAdminProxyIT {
 
     @Test
     void validCollectionNamesWithoutAliases() throws IOException, SolrServerException {
-        assertThat(subject.areCollectionsUp(Arrays.asList("bioentities" ), "bulk-analytics")).isTrue();
+        assertThat(subject.areCollectionsUp(
+                ImmutableSet.of("bioentities"),
+                ImmutableSet.of()))
+                .isTrue();
     }
 
     @Test
     void validCollectionNamesWithAliases() throws IOException, SolrServerException {
         assertThat(
                 subject.areCollectionsUp(
-                        Arrays.asList("bioentities"),
-                        "bulk-analytics", "scxa-analytics", "scxa-gene2experiment"))
+                        ImmutableSet.of("bioentities"),
+                        ImmutableSet.of("bulk-analytics", "scxa-analytics", "scxa-gene2experiment")))
                 .isTrue();
     }
 
     @Test
     void invalidCollectionName() {
         assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> subject.areCollectionsUp(Collections.singletonList("foo")));
+                .isThrownBy(() -> subject.areCollectionsUp(ImmutableSet.of("foo"), ImmutableSet.of()));
     }
 
     @Test
     void invalidAlias() {
         assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> subject.areCollectionsUp(Collections.singletonList("bioentities"), "foo"));
+                .isThrownBy(() -> subject.areCollectionsUp(ImmutableSet.of(), ImmutableSet.of("foo")));
     }
 }


### PR DESCRIPTION
`SolrAdminProxy`’s API is now more general by acceptin arguments of type `Collection<String>` in both fields. This trickles down to `HealthCheckService`.

`HealthChecker` is now a class that returns the results to the controller, so that the job of the latter is just to initialise it and serialise the results to JSON.