### PR TITLE
Feature #166446907 – Add featured experiments in Single Cell Expression Atlas

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/testutils/RandomDataTestUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/testutils/RandomDataTestUtils.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.http.client.utils.URIBuilder;
 import org.jetbrains.annotations.NotNull;
 import uk.ac.ebi.atlas.model.experiment.sample.AssayGroup;
 import uk.ac.ebi.atlas.model.experiment.sample.BiologicalReplicate;
@@ -29,6 +30,7 @@ import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
@@ -399,5 +401,23 @@ public class RandomDataTestUtils {
                         .orElseThrow(RuntimeException::new);
 
         return ImmutableTriple.of(defaultQueryFactorType, factorTypes, ImmutableSet.copyOf(factorTypesWithValues));
+    }
+
+    public static String generateRandomUrl() throws Exception {
+        var uriBuilder = new URIBuilder()
+                .setScheme(RNG.nextBoolean() ? "https" : "http")
+                .setHost(
+                        IntStream.range(1, RNG.nextInt(2, 4))
+                                .boxed()
+                                .map(__ -> randomAlphabetic(3, 10).toLowerCase())
+                                .collect(joining(".")) +
+                                "." + randomAlphabetic(3, 5).toLowerCase())
+                .setPath(RNG.nextBoolean() ? randomAlphabetic(5, 20).toLowerCase() : "");
+
+        if (RNG.nextBoolean()) {
+            uriBuilder.setFragment(randomAlphabetic(5, 20).toLowerCase());
+        }
+
+        return uriBuilder.build().toString();
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/utils/ReactomeClient.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/ReactomeClient.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 

--- a/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
@@ -1,7 +1,10 @@
 package uk.ac.ebi.atlas.utils;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
+
+import java.util.Optional;
 
 public class UrlHelpers {
     public static String getExperimentsFilteredBySpeciesUrl(String species) {
@@ -48,11 +51,31 @@ public class UrlHelpers {
                 .toUriString();
     }
 
-    public static String getExperimentSetUrl(String keyword) {
+    private static String getExperimentSetUrl(String keyword) {
         return ServletUriComponentsBuilder.fromCurrentContextPath()
                         .path("/experiments")
                         .query("experimentSet={keyword}")
                         .buildAndExpand(keyword)
                         .toUriString();
+    }
+
+    public static Pair<Optional<String>, Optional<String>> getExperimentSetLink(String keyword) {
+        return getLinkWithEmptyLabel(getExperimentSetUrl(keyword));
+    }
+
+    public static Pair<String, Optional<String>> getExperimentLink(String label, String accession) {
+        return Pair.of(label, Optional.of(getExperimentUrl(accession)));
+    }
+
+    public static Pair<Optional<String>, Optional<String>> getLinkWithEmptyLabel(String link) {
+        return Pair.of(Optional.empty(), Optional.of(link));
+    }
+
+    public static Pair<Optional<String>, Optional<String>> getExperimentLink(String accession) {
+        return getLinkWithEmptyLabel(getExperimentUrl(accession));
+    }
+
+    public void foo() {
+        getExperimentLink(null);
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/utils/package-info.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package uk.ac.ebi.atlas.utils;
+
+import org.springframework.lang.NonNullApi;


### PR DESCRIPTION
Both Expression Atlas and Single Cell Expression Atlas show featured experiments, so a bit of refactoring is in order to keep the codebase DRY.