### PR TITLE
Chore #166930142 – Improve caching

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyDao.java
@@ -1,34 +1,48 @@
 package uk.ac.ebi.atlas.bioentity.properties;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.apache.solr.client.solrj.SolrQuery;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.controllers.BioentityNotFoundException;
 import uk.ac.ebi.atlas.solr.BioentityPropertyName;
 import uk.ac.ebi.atlas.solr.bioentities.query.BioentitiesSolrClient;
 import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
+import uk.ac.ebi.atlas.solr.cloud.TupleStreamer;
 import uk.ac.ebi.atlas.solr.cloud.collections.AnalyticsCollectionProxy;
+import uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy;
 import uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder;
+import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.source.SearchStreamBuilder;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static uk.ac.ebi.atlas.bioentity.properties.BioEntityCardProperties.BIOENTITY_PROPERTY_NAMES;
 import static uk.ac.ebi.atlas.solr.BioentityPropertyName.ENSGENE;
 import static uk.ac.ebi.atlas.solr.cloud.collections.AnalyticsCollectionProxy.BIOENTITY_IDENTIFIER_SEARCH;
 import static uk.ac.ebi.atlas.solr.cloud.collections.AnalyticsCollectionProxy.IS_PRIVATE;
+import static uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER;
+import static uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy.PROPERTY_NAME;
+import static uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy.PROPERTY_VALUE;
+import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder.SOLR_MAX_ROWS;
 
 @Component
 public class BioEntityPropertyDao {
     private final BioentitiesSolrClient solrClient;
     private final AnalyticsCollectionProxy analyticsCollectionProxy;
+    private final BioentitiesCollectionProxy bioentitiesCollectionProxy;
 
     public BioEntityPropertyDao(BioentitiesSolrClient gxaSolrClient,
                                 SolrCloudCollectionProxyFactory collectionProxyFactory) {
         this.solrClient = gxaSolrClient;
         this.analyticsCollectionProxy = collectionProxyFactory.create(AnalyticsCollectionProxy.class);
+        this.bioentitiesCollectionProxy = collectionProxyFactory.create(BioentitiesCollectionProxy.class);
     }
 
     public Set<String> fetchPropertyValuesForGeneId(String identifier, BioentityPropertyName propertyName) {
@@ -44,14 +58,14 @@ public class BioEntityPropertyDao {
 
     @Cacheable("bioentityProperties")
     public Map<BioentityPropertyName, Set<String>> fetchGenePageProperties(String identifier) {
-        Map<BioentityPropertyName, Set<String>> propertiesByName =
-                solrClient.getMap(identifier, BIOENTITY_PROPERTY_NAMES);
+        var propertiesByName = solrClient.getMap(identifier, BIOENTITY_PROPERTY_NAMES);
 
         if (propertiesByName.isEmpty()) {
-            SolrQueryBuilder<AnalyticsCollectionProxy> solrQueryBuilder = new SolrQueryBuilder<>();
-            solrQueryBuilder
-                    .addFilterFieldByTerm(IS_PRIVATE, "false")
-                    .addQueryFieldByTerm(BIOENTITY_IDENTIFIER_SEARCH, identifier);
+            var solrQueryBuilder =
+                    new SolrQueryBuilder<AnalyticsCollectionProxy>()
+                            .addFilterFieldByTerm(IS_PRIVATE, "false")
+                            .addQueryFieldByTerm(BIOENTITY_IDENTIFIER_SEARCH, identifier);
+
             if (analyticsCollectionProxy.query(solrQueryBuilder).getResults().isEmpty()) {
                 throw new BioentityNotFoundException("Gene/protein <em>" + identifier + "</em> not found.");
             } else {
@@ -62,5 +76,25 @@ public class BioEntityPropertyDao {
         }
 
         return propertiesByName;
+    }
+
+    public ImmutableMap<String, String> getSymbolsForGeneIds(Collection<String> geneIds) {
+        var bioentitiesQueryBuilder =
+                new SolrQueryBuilder<BioentitiesCollectionProxy>()
+                        .addQueryFieldByTerm(BIOENTITY_IDENTIFIER, geneIds)
+                        .addQueryFieldByTerm(PROPERTY_NAME, BioentityPropertyName.SYMBOL.name())
+                        .setFieldList(Arrays.asList(BIOENTITY_IDENTIFIER, PROPERTY_VALUE))
+                        .sortBy(BIOENTITY_IDENTIFIER, SolrQuery.ORDER.asc)
+                        .setRows(SOLR_MAX_ROWS);
+
+        var bioentitiesSearchBuilder = new SearchStreamBuilder<>(bioentitiesCollectionProxy, bioentitiesQueryBuilder);
+
+        try (var tupleStreamer = TupleStreamer.of(bioentitiesSearchBuilder.build())) {
+            return tupleStreamer
+                    .get()
+                    .collect(toImmutableMap(
+                            tuple -> tuple.getString("bioentity_identifier"),
+                            tuple -> tuple.getString("property_value")));
+        }
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTable.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTable.java
@@ -31,9 +31,8 @@ public class ExperimentDesignTable {
         );
 
         JsonArray data = new JsonArray();
-        for (String runOrAssay: experiment.getExperimentDesign().getAllRunOrAssay()) {
-            data.addAll(dataRow(runOrAssay));
-        }
+        experiment.getExperimentDesign().getAllRunOrAssay().stream().limit(1000).forEach(
+                runOrAssay -> data.addAll(dataRow(runOrAssay)));
 
         JsonObject result = new JsonObject();
         result.add("headers", headers);

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTable.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTable.java
@@ -17,6 +17,7 @@ import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 // One idea: pass in a function to the constructor of experiment design, made from the list of contrasts or assay
 // groups, that does this instead
 public class ExperimentDesignTable {
+    public static final int JSON_TABLE_MAX_ROWS = 1000;
     private final Experiment<? extends ReportsGeneExpression> experiment;
 
     public ExperimentDesignTable(Experiment<? extends ReportsGeneExpression> experiment) {
@@ -31,7 +32,7 @@ public class ExperimentDesignTable {
         );
 
         JsonArray data = new JsonArray();
-        experiment.getExperimentDesign().getAllRunOrAssay().stream().limit(1000).forEach(
+        experiment.getExperimentDesign().getAllRunOrAssay().stream().limit(JSON_TABLE_MAX_ROWS).forEach(
                 runOrAssay -> data.addAll(dataRow(runOrAssay)));
 
         JsonObject result = new JsonObject();

--- a/src/test/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyDaoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyDaoIT.java
@@ -1,27 +1,26 @@
 package uk.ac.ebi.atlas.bioentity.properties;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.ac.ebi.atlas.configuration.TestConfig;
 import uk.ac.ebi.atlas.solr.BioentityPropertyName;
 
 import javax.inject.Inject;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertThat;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = TestConfig.class)
-public class BioEntityPropertyDaoIT {
+class BioEntityPropertyDaoIT {
     private static final String MOUSE_GENE_ID = "ENSMUSG00000029816";
     private static final int MIN_NUMBER_OF_PROPERTIES = 50;
     private static final int MIN_NUMBER_OF_ORTHOLOGS = 20;
@@ -32,60 +31,67 @@ public class BioEntityPropertyDaoIT {
     private BioEntityPropertyDao subject;
 
     @Test
-    public void fetchGenePageProperties() {
+    void fetchGenePageProperties() {
         Map<BioentityPropertyName, Set<String>> properties =
                 subject.fetchGenePageProperties(MOUSE_GENE_ID);
 
-        assertThat(
-                numberOfValues(properties),
-                greaterThan(MIN_NUMBER_OF_PROPERTIES));
-        assertThat(
-                properties.get(BioentityPropertyName.SYNONYM).size(),
-                is(3));
-        assertThat(
-                properties.get(BioentityPropertyName.SYNONYM),
-                containsInAnyOrder("DC-HIL", "Dchil", "Osteoactivin"));
-        assertThat(
-                properties.get(BioentityPropertyName.ORTHOLOG).size(),
-                is(greaterThan(MIN_NUMBER_OF_ORTHOLOGS)));
-        assertThat(
-                properties.get(BioentityPropertyName.GO).size(),
-                is(greaterThan(MIN_NUMBER_OF_GO_TERMS)));
-        assertThat(
-                properties.get(BioentityPropertyName.INTERPRO),
-                hasItems("IPR000601", "IPR022409", "IPR013783"));
-        assertThat(
-                properties.get(BioentityPropertyName.ENSFAMILY_DESCRIPTION),
-                containsInAnyOrder("PRECURSOR"));
-        assertThat(
-                properties.get(BioentityPropertyName.ENSGENE),
-                containsInAnyOrder("ENSMUSG00000029816"));
-        assertThat(
-                properties.get(BioentityPropertyName.ENTREZGENE),
-                containsInAnyOrder("93695"));
-        assertThat(
-                properties.get(BioentityPropertyName.UNIPROT),
-                containsInAnyOrder("A0A0N4SVG5", "Q8BVA0", "Q99P91"));
-        assertThat(
-                properties.get(BioentityPropertyName.MGI_ID),
-                containsInAnyOrder("MGI:1934765"));
-        assertThat(
-                properties.get(BioentityPropertyName.GENE_BIOTYPE),
-                containsInAnyOrder("protein_coding"));
-        assertThat(
-                properties.get(BioentityPropertyName.DESIGN_ELEMENT).size(),
-                is(greaterThan(MIN_NUMBER_OF_DESIGN_ELEMENTS)));
+        assertThat(numberOfValues(properties))
+                .isGreaterThan(MIN_NUMBER_OF_PROPERTIES);
+        assertThat(properties.get(BioentityPropertyName.SYNONYM))
+                .hasSize(3);
+        assertThat(properties.get(BioentityPropertyName.SYNONYM))
+                .containsExactlyInAnyOrder("DC-HIL", "Dchil", "Osteoactivin");
+        assertThat(properties.get(BioentityPropertyName.ORTHOLOG).size())
+                .isGreaterThan(MIN_NUMBER_OF_ORTHOLOGS);
+        assertThat(properties.get(BioentityPropertyName.GO).size())
+                .isGreaterThan(MIN_NUMBER_OF_GO_TERMS);
+        assertThat(properties.get(BioentityPropertyName.INTERPRO))
+                .contains("IPR000601", "IPR022409", "IPR013783");
+        assertThat(properties.get(BioentityPropertyName.ENSFAMILY_DESCRIPTION))
+                .contains("PRECURSOR");
+        assertThat(properties.get(BioentityPropertyName.ENSGENE))
+                .contains("ENSMUSG00000029816");
+        assertThat(properties.get(BioentityPropertyName.ENTREZGENE))
+                .contains("93695");
+        assertThat(properties.get(BioentityPropertyName.UNIPROT))
+                .contains("A0A0N4SVG5", "Q8BVA0", "Q99P91");
+        assertThat(properties.get(BioentityPropertyName.MGI_ID))
+                .contains("MGI:1934765");
+        assertThat(properties.get(BioentityPropertyName.GENE_BIOTYPE))
+                .contains("protein_coding");
+        assertThat(properties.get(BioentityPropertyName.DESIGN_ELEMENT).size())
+                .isGreaterThan(MIN_NUMBER_OF_DESIGN_ELEMENTS);
     }
 
     @Test
-    public void findPropertyValuesForGeneId() {
-        assertThat(
-                subject.fetchPropertyValuesForGeneId("ENSG00000179218", BioentityPropertyName.SYMBOL),
-                hasItem("CALR"));
-        assertThat(
-                subject.fetchPropertyValuesForGeneId("ENSMUSG00000029816", BioentityPropertyName.SYMBOL),
-                hasItem("Gpnmb"));
+    void findPropertyValuesForGeneId() {
+        assertThat(subject.fetchPropertyValuesForGeneId("ENSG00000179218", BioentityPropertyName.SYMBOL))
+                .contains("CALR");
+        assertThat(subject.fetchPropertyValuesForGeneId("ENSMUSG00000029816", BioentityPropertyName.SYMBOL))
+                .contains("Gpnmb");
     }
+
+    @Test
+    void validGeneIdsReturnAssociatedSymbols() {
+        List<String> geneIds = Arrays.asList("ENSG00000001626", "ENSMUSG00000033952", "ENSDARG00000103754");
+
+        assertThat(subject.getSymbolsForGeneIds(geneIds))
+                .hasSize(3)
+                .containsOnlyKeys(geneIds.toArray(new String[0]));
+    }
+
+    @Test
+    void geneIdsWithoutSymbolsReturnNoResults() {
+        List<String> geneIds = Collections.singletonList("FAKE_GENE_ID");
+
+        assertThat(subject.getSymbolsForGeneIds(geneIds)).isEmpty();
+    }
+
+    @Test
+    void emptyGeneIdListReturnsNoResults() {
+        assertThat(subject.getSymbolsForGeneIds(emptyList())).isEmpty();
+    }
+
 
     private int numberOfValues(Map<?, ? extends Set<?>> map) {
         int n = 0;


### PR DESCRIPTION
This change shouldn’t impact the integration of `atlas-web-core` into `atlas-web-bulk` or `atlas-web-single-cell`.

I refactored a method to fetch symbols from the bioentities collection that should belong in the `BioEntittyPropertyDao` class, and moved its tests there as well.

I also fixed a test that sometimes failed on the master branch. Let’s hope we have stable green builds now!