### PR TITLE
Change PMCEurope query structure to {DOI}/{PubmedID}:{query}

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentAttributesService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentAttributesService.java
@@ -45,9 +45,9 @@ public class ExperimentAttributesService {
         result.put("factors", experiment.getExperimentDesign().getFactorHeaders());
 
         if (!experiment.getDois().isEmpty()) {
-            result.put("publications", getPublications(experiment.getDois()));
+            result.put("publications", getPublicationsByDOI(experiment.getDois()));
         } else if (!experiment.getPubMedIds().isEmpty()) {
-            result.put("publications", getPublications(experiment.getPubMedIds()));
+            result.put("publications", getPublicationsByPubmedID(experiment.getPubMedIds()));
         }
 
         result.put("longDescription", idfParser.parse(experiment.getAccession()).getExperimentDescription());
@@ -75,9 +75,17 @@ public class ExperimentAttributesService {
         return result;
     }
 
-    private ImmutableList<Publication> getPublications(Collection<String> identifiers) {
+    private ImmutableList<Publication> getPublicationsByDOI(Collection<String> identifiers) {
         return identifiers.stream()
-                .map(europePmcClient::getPublicationByIdentifier)
+                .map(europePmcClient::getPublicationByDOI)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(toImmutableList());
+    }
+
+    private ImmutableList<Publication> getPublicationsByPubmedID(Collection<String> identifiers) {
+        return identifiers.stream()
+                .map(europePmcClient::getPublicationByPubmedID)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(toImmutableList());

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentAttributesService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentAttributesService.java
@@ -45,9 +45,9 @@ public class ExperimentAttributesService {
         result.put("factors", experiment.getExperimentDesign().getFactorHeaders());
 
         if (!experiment.getDois().isEmpty()) {
-            result.put("publications", getPublicationsByDOI(experiment.getDois()));
+            result.put("publications", getPublicationsByDoi(experiment.getDois()));
         } else if (!experiment.getPubMedIds().isEmpty()) {
-            result.put("publications", getPublicationsByPubmedID(experiment.getPubMedIds()));
+            result.put("publications", getPublicationsByPubmedId(experiment.getPubMedIds()));
         }
 
         result.put("longDescription", idfParser.parse(experiment.getAccession()).getExperimentDescription());
@@ -75,17 +75,17 @@ public class ExperimentAttributesService {
         return result;
     }
 
-    private ImmutableList<Publication> getPublicationsByDOI(Collection<String> identifiers) {
+    private ImmutableList<Publication> getPublicationsByDoi(Collection<String> identifiers) {
         return identifiers.stream()
-                .map(europePmcClient::getPublicationByDOI)
+                .map(europePmcClient::getPublicationByDoi)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(toImmutableList());
     }
 
-    private ImmutableList<Publication> getPublicationsByPubmedID(Collection<String> identifiers) {
+    private ImmutableList<Publication> getPublicationsByPubmedId(Collection<String> identifiers) {
         return identifiers.stream()
-                .map(europePmcClient::getPublicationByPubmedID)
+                .map(europePmcClient::getPublicationByPubmedId)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(toImmutableList());

--- a/src/main/java/uk/ac/ebi/atlas/utils/EuropePmcClient.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/EuropePmcClient.java
@@ -26,13 +26,13 @@ public class EuropePmcClient {
         this.mapper = new ObjectMapper();
     }
 
-    public Optional<Publication> getPublicationByDOI(String DOI) {
+    public Optional<Publication> getPublicationByDoi(String doi) {
         // Enclose query in quotes as EuropePmc only searches up to the slash for DOIs not enclosed in quotes
-        DOI = "DOI:" + "\"" + DOI + "\"";
-        return parseResponseWithOneResult(DOI);
+        doi = "DOI:" + "\"" + doi + "\"";
+        return parseResponseWithOneResult(doi);
     }
 
-    public Optional<Publication> getPublicationByPubmedID(String pubmedId) {
+    public Optional<Publication> getPublicationByPubmedId(String pubmedId) {
         pubmedId = "SRC:MED AND EXT_ID:" + "\"" + pubmedId + "\"";
         return parseResponseWithOneResult(pubmedId);
     }

--- a/src/main/java/uk/ac/ebi/atlas/utils/EuropePmcClient.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/EuropePmcClient.java
@@ -26,15 +26,18 @@ public class EuropePmcClient {
         this.mapper = new ObjectMapper();
     }
 
-    // Identifier should be either DOI or Pubmed ID
-    public Optional<Publication> getPublicationByIdentifier(String identifier) {
-        return parseResponseWithOneResult(identifier);
+    public Optional<Publication> getPublicationByDOI(String DOI) {
+        // Enclose query in quotes as EuropePmc only searches up to the slash for DOIs not enclosed in quotes
+        DOI = "DOI:" + "\"" + DOI + "\"";
+        return parseResponseWithOneResult(DOI);
+    }
+
+    public Optional<Publication> getPublicationByPubmedID(String pubmedId) {
+        pubmedId = "SRC:MED AND EXT_ID:" + "\"" + pubmedId + "\"";
+        return parseResponseWithOneResult(pubmedId);
     }
 
     private Optional<Publication> parseResponseWithOneResult(String query) {
-        // Enclose query in quotes as EuropePmc only searches up to the slash for DOIs not enclosed in quotes
-        query = "\"" + query + "\"";
-
         try {
             ResponseEntity<String> response = restTemplate.getForEntity(MessageFormat.format(URL, query), String.class);
 

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentAttributesServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentAttributesServiceTest.java
@@ -50,7 +50,8 @@ public class ExperimentAttributesServiceTest {
 
     @Test
     public void getAttributesForBaselineExperimentWithNoPublications() {
-        when(europePmcClientMock.getPublicationByIdentifier(anyString())).thenReturn(Optional.empty());
+        when(europePmcClientMock.getPublicationByDOI(anyString())).thenReturn(Optional.empty());
+        when(europePmcClientMock.getPublicationByPubmedID(anyString())).thenReturn(Optional.empty());
         when(idfParser.parse(any()))
                 .thenReturn(new IdfParserOutput("title", "12345","description", Lists.emptyList(), 0, Lists.emptyList()));
 
@@ -69,9 +70,9 @@ public class ExperimentAttributesServiceTest {
     public void getAttributesForBaselineExperimentWithPublicationsFromDois() {
         List<String> dois = Arrays.asList("100.100/doi", "999.100/another-doi");
 
-        when(europePmcClientMock.getPublicationByIdentifier("100.100/doi"))
+        when(europePmcClientMock.getPublicationByDOI("100.100/doi"))
                 .thenReturn(Optional.of(new Publication("", "100.100/doi", "Publication 1")));
-        when(europePmcClientMock.getPublicationByIdentifier("999.100/another-doi"))
+        when(europePmcClientMock.getPublicationByDOI("999.100/another-doi"))
                 .thenReturn(Optional.of(new Publication("", "999.100/another-doi", "Publication 2")));
         when(idfParser.parse(any()))
                 .thenReturn(new IdfParserOutput("title", "12345","description", Lists.emptyList(), 0, Lists.emptyList()));
@@ -87,9 +88,9 @@ public class ExperimentAttributesServiceTest {
     public void getAttributesForBaselineExperimentWithPublicationsFromPubmedIds() {
         List<String> pubmedIds = Arrays.asList("1123", "1235");
 
-        when(europePmcClientMock.getPublicationByIdentifier("1123"))
+        when(europePmcClientMock.getPublicationByPubmedID("1123"))
                 .thenReturn(Optional.of(new Publication("1123", "100.100/doi", "Publication 1")));
-        when(europePmcClientMock.getPublicationByIdentifier("1235"))
+        when(europePmcClientMock.getPublicationByPubmedID("1235"))
                 .thenReturn(Optional.of(new Publication("1235", "999.100/another-doi", "Publication 2")));
         when(idfParser.parse(any()))
                 .thenReturn(new IdfParserOutput("title", "12345","description", Lists.emptyList(), 0, Lists.emptyList()));

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentAttributesServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentAttributesServiceTest.java
@@ -50,8 +50,8 @@ public class ExperimentAttributesServiceTest {
 
     @Test
     public void getAttributesForBaselineExperimentWithNoPublications() {
-        when(europePmcClientMock.getPublicationByDOI(anyString())).thenReturn(Optional.empty());
-        when(europePmcClientMock.getPublicationByPubmedID(anyString())).thenReturn(Optional.empty());
+        when(europePmcClientMock.getPublicationByDoi(anyString())).thenReturn(Optional.empty());
+        when(europePmcClientMock.getPublicationByPubmedId(anyString())).thenReturn(Optional.empty());
         when(idfParser.parse(any()))
                 .thenReturn(new IdfParserOutput("title", "12345","description", Lists.emptyList(), 0, Lists.emptyList()));
 
@@ -70,9 +70,9 @@ public class ExperimentAttributesServiceTest {
     public void getAttributesForBaselineExperimentWithPublicationsFromDois() {
         List<String> dois = Arrays.asList("100.100/doi", "999.100/another-doi");
 
-        when(europePmcClientMock.getPublicationByDOI("100.100/doi"))
+        when(europePmcClientMock.getPublicationByDoi("100.100/doi"))
                 .thenReturn(Optional.of(new Publication("", "100.100/doi", "Publication 1")));
-        when(europePmcClientMock.getPublicationByDOI("999.100/another-doi"))
+        when(europePmcClientMock.getPublicationByDoi("999.100/another-doi"))
                 .thenReturn(Optional.of(new Publication("", "999.100/another-doi", "Publication 2")));
         when(idfParser.parse(any()))
                 .thenReturn(new IdfParserOutput("title", "12345","description", Lists.emptyList(), 0, Lists.emptyList()));
@@ -88,9 +88,9 @@ public class ExperimentAttributesServiceTest {
     public void getAttributesForBaselineExperimentWithPublicationsFromPubmedIds() {
         List<String> pubmedIds = Arrays.asList("1123", "1235");
 
-        when(europePmcClientMock.getPublicationByPubmedID("1123"))
+        when(europePmcClientMock.getPublicationByPubmedId("1123"))
                 .thenReturn(Optional.of(new Publication("1123", "100.100/doi", "Publication 1")));
-        when(europePmcClientMock.getPublicationByPubmedID("1235"))
+        when(europePmcClientMock.getPublicationByPubmedId("1235"))
                 .thenReturn(Optional.of(new Publication("1235", "999.100/another-doi", "Publication 2")));
         when(idfParser.parse(any()))
                 .thenReturn(new IdfParserOutput("title", "12345","description", Lists.emptyList(), 0, Lists.emptyList()));

--- a/src/test/java/uk/ac/ebi/atlas/utils/EuropePmcClientIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/utils/EuropePmcClientIT.java
@@ -20,7 +20,7 @@ public class EuropePmcClientIT {
 
     @Test
     public void publicationForValidDoi() {
-        Optional<Publication> result = subject.getPublicationByIdentifier("10.1126/sciimmunol.aan8664");
+        Optional<Publication> result = subject.getPublicationByDOI("10.1126/sciimmunol.aan8664");
 
         assertThat(result.isPresent()).isTrue();
 
@@ -34,7 +34,7 @@ public class EuropePmcClientIT {
 
     @Test
     public void publicationForValidPubmedId() {
-        Optional<Publication> result = subject.getPublicationByIdentifier("29352091");
+        Optional<Publication> result = subject.getPublicationByPubmedID("29352091");
 
         assertThat(result.isPresent()).isTrue();
 
@@ -47,8 +47,10 @@ public class EuropePmcClientIT {
 
     @Test
     public void noResultForEmptyIdentifier() {
-        Optional<Publication> result = subject.getPublicationByIdentifier("");
+        Optional<Publication> result1 = subject.getPublicationByDOI("");
+        Optional<Publication> result2 = subject.getPublicationByPubmedID("");
 
-        assertThat(result.isPresent()).isFalse();
+        assertThat(result1.isPresent()).isFalse();
+        assertThat(result2.isPresent()).isFalse();
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/utils/EuropePmcClientIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/utils/EuropePmcClientIT.java
@@ -20,7 +20,7 @@ public class EuropePmcClientIT {
 
     @Test
     public void publicationForValidDoi() {
-        Optional<Publication> result = subject.getPublicationByDOI("10.1126/sciimmunol.aan8664");
+        Optional<Publication> result = subject.getPublicationByDoi("10.1126/sciimmunol.aan8664");
 
         assertThat(result.isPresent()).isTrue();
 
@@ -34,7 +34,7 @@ public class EuropePmcClientIT {
 
     @Test
     public void publicationForValidPubmedId() {
-        Optional<Publication> result = subject.getPublicationByPubmedID("29352091");
+        Optional<Publication> result = subject.getPublicationByPubmedId("29352091");
 
         assertThat(result.isPresent()).isTrue();
 
@@ -47,8 +47,8 @@ public class EuropePmcClientIT {
 
     @Test
     public void noResultForEmptyIdentifier() {
-        Optional<Publication> result1 = subject.getPublicationByDOI("");
-        Optional<Publication> result2 = subject.getPublicationByPubmedID("");
+        Optional<Publication> result1 = subject.getPublicationByDoi("");
+        Optional<Publication> result2 = subject.getPublicationByPubmedId("");
 
         assertThat(result1.isPresent()).isFalse();
         assertThat(result2.isPresent()).isFalse();

--- a/src/test/java/uk/ac/ebi/atlas/utils/EuropePmcClientTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/utils/EuropePmcClientTest.java
@@ -34,7 +34,8 @@ public class EuropePmcClientTest {
         when(restTemplateMock.getForEntity(MessageFormat.format(URL, anyString()), eq(String.class)))
                 .thenThrow(RestClientException.class);
 
-        assertThat(subject.getPublicationByIdentifier("foo")).isEmpty();
+        assertThat(subject.getPublicationByDOI("foo")).isEmpty();
+        assertThat(subject.getPublicationByPubmedID("foo")).isEmpty();
     }
 
 }

--- a/src/test/java/uk/ac/ebi/atlas/utils/EuropePmcClientTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/utils/EuropePmcClientTest.java
@@ -34,8 +34,8 @@ public class EuropePmcClientTest {
         when(restTemplateMock.getForEntity(MessageFormat.format(URL, anyString()), eq(String.class)))
                 .thenThrow(RestClientException.class);
 
-        assertThat(subject.getPublicationByDOI("foo")).isEmpty();
-        assertThat(subject.getPublicationByPubmedID("foo")).isEmpty();
+        assertThat(subject.getPublicationByDoi("foo")).isEmpty();
+        assertThat(subject.getPublicationByPubmedId("foo")).isEmpty();
     }
 
 }


### PR DESCRIPTION
The bug was discovered as our current query structure didn't provide good responses from EuropePMC. As per discussion with Europe PMC people, they suggested using the key: value structure for querying. More details in the [pivotal ticket.](https://www.pivotaltracker.com/story/show/168224103)

Link to green build:
http://bar:8085/browse/ATLAS-ATLASWEBCOREGRCI4