### PR TITLE
Add project filter experiment table

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/Experiment.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/Experiment.java
@@ -28,6 +28,19 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 // The displayName is a bit confusing - it's used for baseline landing page and I think only there.
 // There's also a title which is fetched from the IDF file.
 public abstract class Experiment<R extends ReportsGeneExpression> implements Serializable {
+    private final static ImmutableMap<String, ImmutableList<String>> EXPERIMENT2PROJECT =
+            ImmutableMap.<String, ImmutableList<String>>builder()
+                    .put("E-EHCA-2", ImmutableList.of("Human Cell Atlas"))
+                    .put("E-GEOD-81547", ImmutableList.of("Human Cell Atlas"))
+                    .put("E-GEOD-93593", ImmutableList.of("Human Cell Atlas"))
+                    .put("E-MTAB-5061", ImmutableList.of("Human Cell Atlas"))
+                    .put("E-GEOD-106540", ImmutableList.of("Human Cell Atlas"))
+                    .put("E-ENAD-15", ImmutableList.of("Human Cell Atlas", "Chan-Zuckerberg Biohub"))
+                    .put("E-MTAB-6701", ImmutableList.of("Human Cell Atlas"))
+                    .put("E-MTAB-66782", ImmutableList.of("Human Cell Atlas"))
+                    .put("E-CURD-2", ImmutableList.of("Malaria Cell Atlas"))
+                    .build();
+
     private final ExperimentType type;
     private final String accession;
     protected final String description;
@@ -47,7 +60,6 @@ public abstract class Experiment<R extends ReportsGeneExpression> implements Ser
     private final ExperimentDisplayDefaults experimentDisplayDefaults;
     private final boolean isPrivate;
     private String accessKey;
-    private ImmutableMap<String, List<String>> experiment2Project;
 
     public Experiment(@NotNull ExperimentType type,
                       @NotNull String accession,
@@ -96,8 +108,6 @@ public abstract class Experiment<R extends ReportsGeneExpression> implements Ser
         this.experimentDisplayDefaults = experimentDisplayDefaults;
         this.isPrivate = isPrivate;
         this.accessKey = accessKey;
-
-        buildExperimentMapping();
     }
 
     @NotNull
@@ -208,18 +218,17 @@ public abstract class Experiment<R extends ReportsGeneExpression> implements Ser
 
     @NotNull
     public ExperimentInfo buildExperimentInfo() {
-        ExperimentInfo experimentInfo = new ExperimentInfo();
-        experimentInfo.setExperimentAccession(accession);
-        experimentInfo.setLoadDate(new SimpleDateFormat("dd-MM-yyyy").format(loadDate));
-        experimentInfo.setLastUpdate(new SimpleDateFormat("dd-MM-yyyy").format(lastUpdate));
-        experimentInfo.setExperimentDescription(description);
-        experimentInfo.setSpecies(species.getName());
-        experimentInfo.setKingdom(species.getKingdom());
-        experimentInfo.setExperimentType(type);
-        experimentInfo.setExperimentalFactors(experimentDesign.getFactorHeaders());
-        experimentInfo.setNumberOfAssays(getAnalysedAssays().size());
-        experimentInfo.setExperimentProjects(getExperimentProjects(accession));
-        return experimentInfo;
+        return new ExperimentInfo()
+                .setExperimentAccession(accession)
+                .setLoadDate(new SimpleDateFormat("dd-MM-yyyy").format(loadDate))
+                .setLastUpdate(new SimpleDateFormat("dd-MM-yyyy").format(lastUpdate))
+                .setExperimentDescription(description)
+                .setSpecies(species.getName())
+                .setKingdom(species.getKingdom())
+                .setExperimentType(type)
+                .setExperimentalFactors(experimentDesign.getFactorHeaders())
+                .setNumberOfAssays(getAnalysedAssays().size())
+                .setExperimentProjects(EXPERIMENT2PROJECT.getOrDefault(accession, ImmutableList.of()));
     }
 
     @NotNull
@@ -253,22 +262,4 @@ public abstract class Experiment<R extends ReportsGeneExpression> implements Ser
 
     @NotNull
     protected abstract ImmutableList<JsonObject> propertiesForAssay(@NotNull String runOrAssay);
-
-    private List<String> getExperimentProjects(String accession) {
-        return experiment2Project.get(accession) == null ? ImmutableList.of() : experiment2Project.get(accession);
-    }
-
-    private void buildExperimentMapping() {
-        experiment2Project = ImmutableMap.<String, List<String>>builder()
-                .put("E-EHCA-2", ImmutableList.of("HCA"))
-                .put("E-GEOD-81547", ImmutableList.of("HCA"))
-                .put("E-GEOD-93593", ImmutableList.of("HCA"))
-                .put("E-MTAB-5061", ImmutableList.of("HCA"))
-                .put("E-GEOD-106540", ImmutableList.of("HCA"))
-                .put("E-ENAD-15", ImmutableList.of("HCA", "CZ-Biohub"))
-                .put("E-MTAB-6701", ImmutableList.of("HCA"))
-                .put("E-MTAB-66782", ImmutableList.of("HCA"))
-                .put("E-CURD-2", ImmutableList.of("Malaria-Cell-Atlas"))
-                .build();
-    }
 }

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/Experiment.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/Experiment.java
@@ -48,6 +48,8 @@ public abstract class Experiment<R extends ReportsGeneExpression> implements Ser
     private final boolean isPrivate;
     private String accessKey;
 
+    private ImmutableMap<String, List<String>> experiment2Project;
+
     public Experiment(@NotNull ExperimentType type,
                       @NotNull String accession,
                       @NotNull String description,
@@ -95,6 +97,8 @@ public abstract class Experiment<R extends ReportsGeneExpression> implements Ser
         this.experimentDisplayDefaults = experimentDisplayDefaults;
         this.isPrivate = isPrivate;
         this.accessKey = accessKey;
+
+        buildExperimentMapping();
     }
 
     @NotNull
@@ -215,6 +219,7 @@ public abstract class Experiment<R extends ReportsGeneExpression> implements Ser
         experimentInfo.setExperimentType(type);
         experimentInfo.setExperimentalFactors(experimentDesign.getFactorHeaders());
         experimentInfo.setNumberOfAssays(getAnalysedAssays().size());
+        experimentInfo.setExperimentProjects(getExperimentProjects(accession));
         return experimentInfo;
     }
 
@@ -249,4 +254,22 @@ public abstract class Experiment<R extends ReportsGeneExpression> implements Ser
 
     @NotNull
     protected abstract ImmutableList<JsonObject> propertiesForAssay(@NotNull String runOrAssay);
+
+    private List<String> getExperimentProjects(String accession) {
+        return experiment2Project.get(accession) == null ? ImmutableList.of() : experiment2Project.get(accession);
+    }
+
+    private void buildExperimentMapping() {
+        experiment2Project = ImmutableMap.<String, List<String>>builder()
+                .put("E-EHCA-2", ImmutableList.of("HCA"))
+                .put("E-GEOD-81547", ImmutableList.of("HCA"))
+                .put("E-GEOD-93593", ImmutableList.of("HCA"))
+                .put("E-MTAB-5061", ImmutableList.of("HCA"))
+                .put("E-GEOD-106540", ImmutableList.of("HCA"))
+                .put("E-ENAD-15", ImmutableList.of("HCA", "CZ-Biohub"))
+                .put("E-MTAB-6701", ImmutableList.of("HCA"))
+                .put("E-MTAB-66782", ImmutableList.of("HCA"))
+                .put("E-CURD-2", ImmutableList.of("Malaria-Cell-Atlas"))
+                .build();
+    }
 }

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/Experiment.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/Experiment.java
@@ -47,7 +47,6 @@ public abstract class Experiment<R extends ReportsGeneExpression> implements Ser
     private final ExperimentDisplayDefaults experimentDisplayDefaults;
     private final boolean isPrivate;
     private String accessKey;
-
     private ImmutableMap<String, List<String>> experiment2Project;
 
     public Experiment(@NotNull ExperimentType type,

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/differential/DifferentialExperiment.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/differential/DifferentialExperiment.java
@@ -81,9 +81,8 @@ public class DifferentialExperiment extends Experiment<Contrast> {
     @Override
     @NotNull
     public ExperimentInfo buildExperimentInfo() {
-        ExperimentInfo experimentInfo = super.buildExperimentInfo();
-        experimentInfo.setNumberOfContrasts(getDataColumnDescriptors().size());
-        return experimentInfo;
+        return super.buildExperimentInfo()
+                .setNumberOfContrasts(getDataColumnDescriptors().size());
     }
 
     @Override

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/differential/microarray/MicroarrayExperiment.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/differential/microarray/MicroarrayExperiment.java
@@ -70,9 +70,8 @@ public class MicroarrayExperiment extends DifferentialExperiment {
     @Override
     @NotNull
     public ExperimentInfo buildExperimentInfo() {
-        ExperimentInfo experimentInfo = super.buildExperimentInfo();
-        experimentInfo.setArrayDesigns(getArrayDesignAccessions());
-        experimentInfo.setArrayDesignNames(getArrayDesignNames());
-        return experimentInfo;
+        return super.buildExperimentInfo()
+            .setArrayDesigns(getArrayDesignAccessions())
+            .setArrayDesignNames(getArrayDesignNames());
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/utils/ExperimentInfo.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/ExperimentInfo.java
@@ -21,6 +21,7 @@ public class ExperimentInfo {
     private List<String> experimentalFactors = new ArrayList<>();
     private List<String> arrayDesigns = ImmutableList.of();
     private List<String> arrayDesignNames = ImmutableList.of();
+    private List<String> experimentProjects = ImmutableList.of();
 
     public ExperimentType getExperimentType() {
         return experimentType;
@@ -118,5 +119,11 @@ public class ExperimentInfo {
 
     public void setLastUpdate(String lastUpdate) {
         this.lastUpdate = lastUpdate;
+    }
+
+    public List<String> getExperimentProjects() { return this.experimentProjects; }
+
+    public void setExperimentProjects(List<String> experimentProjects) {
+        this.experimentProjects = experimentProjects;
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/utils/ExperimentInfo.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/ExperimentInfo.java
@@ -21,38 +21,42 @@ public class ExperimentInfo {
     private List<String> experimentalFactors = new ArrayList<>();
     private List<String> arrayDesigns = ImmutableList.of();
     private List<String> arrayDesignNames = ImmutableList.of();
-    private List<String> experimentProjects = ImmutableList.of();
+    private ImmutableList<String> experimentProjects = ImmutableList.of();
 
     public ExperimentType getExperimentType() {
         return experimentType;
     }
 
-    public void setExperimentType(ExperimentType experimentType) {
+    public ExperimentInfo setExperimentType(ExperimentType experimentType) {
         this.experimentType = experimentType;
+        return this;
     }
 
     public String getExperimentAccession() {
         return experimentAccession;
     }
 
-    public void setExperimentAccession(String experimentAccession) {
+    public ExperimentInfo setExperimentAccession(String experimentAccession) {
         this.experimentAccession = experimentAccession;
+        return this;
     }
 
     public String getExperimentDescription() {
         return experimentDescription;
     }
 
-    public void setExperimentDescription(String experimentDescription) {
+    public ExperimentInfo setExperimentDescription(String experimentDescription) {
         this.experimentDescription = experimentDescription;
+        return this;
     }
 
     public int getNumberOfAssays() {
         return numberOfAssays;
     }
 
-    public void setNumberOfAssays(int numberOfAssays) {
+    public ExperimentInfo setNumberOfAssays(int numberOfAssays) {
         this.numberOfAssays = numberOfAssays;
+        return this;
     }
 
     // Used in EL experiment-list-latest.jsp
@@ -60,40 +64,43 @@ public class ExperimentInfo {
         return numberOfContrasts;
     }
 
-    public void setNumberOfContrasts(int numberOfContrasts) {
+    public ExperimentInfo setNumberOfContrasts(int numberOfContrasts) {
         this.numberOfContrasts = numberOfContrasts;
+        return this;
     }
 
     public String getSpecies() {
         return species;
     }
 
-    public void setSpecies(String species) {
+    public ExperimentInfo setSpecies(String species) {
         this.species = species;
+        return this;
     }
 
-    public String getKingdom() {
-        return kingdom;
-    }
+    public String getKingdom() { return kingdom; }
 
-    public void setKingdom(String kingdom) {
+    public ExperimentInfo setKingdom(String kingdom) {
         this.kingdom = kingdom;
+        return this;
     }
 
     public List<String> getExperimentalFactors() {
         return experimentalFactors;
     }
 
-    public void setExperimentalFactors(Set<String> experimentalFactors) {
+    public ExperimentInfo setExperimentalFactors(Set<String> experimentalFactors) {
         this.experimentalFactors = new ArrayList<>(experimentalFactors);
+        return this;
     }
 
     public List<String> getArrayDesigns() {
         return arrayDesigns;
     }
 
-    public void setArrayDesigns(List<String> arrayDesigns) {
+    public ExperimentInfo setArrayDesigns(List<String> arrayDesigns) {
         this.arrayDesigns = arrayDesigns;
+        return this;
     }
 
     // Used in EL experiment-description.jsp
@@ -101,29 +108,33 @@ public class ExperimentInfo {
         return arrayDesignNames;
     }
 
-    public void setArrayDesignNames(List<String> arrayDesignNames) {
+    public ExperimentInfo setArrayDesignNames(List<String> arrayDesignNames) {
         this.arrayDesignNames = arrayDesignNames;
+        return this;
     }
 
     public String getLoadDate() {
         return loadDate;
     }
 
+    public ExperimentInfo setLoadDate(String loadDate) {
+        this.loadDate = loadDate;
+        return this;
+    }
+
     public String getLastUpdate() {
         return lastUpdate;
     }
 
-    public void setLoadDate(String loadDate) {
-        this.loadDate = loadDate;
-    }
-
-    public void setLastUpdate(String lastUpdate) {
+    public ExperimentInfo setLastUpdate(String lastUpdate) {
         this.lastUpdate = lastUpdate;
+        return this;
     }
 
-    public List<String> getExperimentProjects() { return this.experimentProjects; }
+    public ImmutableList<String> getExperimentProjects() { return this.experimentProjects; }
 
-    public void setExperimentProjects(List<String> experimentProjects) {
+    public ExperimentInfo setExperimentProjects(ImmutableList<String> experimentProjects) {
         this.experimentProjects = experimentProjects;
+        return this;
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentBuilder.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentBuilder.java
@@ -59,7 +59,6 @@ public abstract class ExperimentBuilder<R extends ReportsGeneExpression, E exten
     Species species = generateRandomSpecies();
     ImmutableList<R> samples;
     ExperimentDesign experimentDesign = new ExperimentDesign();
-    ImmutableList<String> experimentProjects = ImmutableList.of("HCA", "CZ-Biohub", "Malaria-Cell-Atlas");
     ImmutableList<String> pubMedIds =
             IntStream.range(0, 5).boxed()
                     .map(__ -> randomNumeric(3, 8))

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentBuilder.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentBuilder.java
@@ -478,7 +478,7 @@ public abstract class ExperimentBuilder<R extends ReportsGeneExpression, E exten
     }
 
     public static class SingleCellBaselineExperimentBuilder extends ExperimentBuilder<Cell,
-            SingleCellBaselineExperiment> {
+                                                                                      SingleCellBaselineExperiment> {
         public SingleCellBaselineExperimentBuilder() {
             experimentType = SINGLE_CELL_RNASEQ_MRNA_BASELINE;
             samples =

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentBuilder.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentBuilder.java
@@ -59,6 +59,7 @@ public abstract class ExperimentBuilder<R extends ReportsGeneExpression, E exten
     Species species = generateRandomSpecies();
     ImmutableList<R> samples;
     ExperimentDesign experimentDesign = new ExperimentDesign();
+    ImmutableList<String> experimentProjects = ImmutableList.of("HCA", "CZ-Biohub", "Malaria-Cell-Atlas");
     ImmutableList<String> pubMedIds =
             IntStream.range(0, 5).boxed()
                     .map(__ -> randomNumeric(3, 8))
@@ -477,7 +478,7 @@ public abstract class ExperimentBuilder<R extends ReportsGeneExpression, E exten
     }
 
     public static class SingleCellBaselineExperimentBuilder extends ExperimentBuilder<Cell,
-                                                                                      SingleCellBaselineExperiment> {
+            SingleCellBaselineExperiment> {
         public SingleCellBaselineExperimentBuilder() {
             experimentType = SINGLE_CELL_RNASEQ_MRNA_BASELINE;
             samples =

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentTest.java
@@ -292,6 +292,8 @@ public class ExperimentTest {
 
         assertThat(builder.build().buildExperimentInfo().getExperimentalFactors())
                 .containsExactlyInAnyOrderElementsOf(builder.experimentDesign.getFactorHeaders());
+        assertThat(builder.build().buildExperimentInfo().getExperimentProjects())
+                .containsExactlyInAnyOrderElementsOf(builder.experimentProjects);
     }
 
     private long countAssays(Collection<TestSample> samples) {

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentTest.java
@@ -288,12 +288,11 @@ public class ExperimentTest {
                         new SimpleDateFormat("dd-MM-yyyy").format(builder.lastUpdate))
                 .hasFieldOrPropertyWithValue("species", builder.species.getName())
                 .hasFieldOrPropertyWithValue("kingdom", builder.species.getKingdom())
-                .hasFieldOrPropertyWithValue("numberOfAssays", Math.toIntExact(countAssays(builder.samples)));
+                .hasFieldOrPropertyWithValue("numberOfAssays", Math.toIntExact(countAssays(builder.samples)))
+                .hasFieldOrProperty("experimentProjects");
 
         assertThat(builder.build().buildExperimentInfo().getExperimentalFactors())
                 .containsExactlyInAnyOrderElementsOf(builder.experimentDesign.getFactorHeaders());
-        assertThat(builder.build().buildExperimentInfo().getExperimentProjects())
-                .containsExactlyInAnyOrderElementsOf(builder.experimentProjects);
     }
 
     private long countAssays(Collection<TestSample> samples) {


### PR DESCRIPTION
To add project filter dropdown in `experiment table` we need to pass it through JSON payload from the backend. For now, I have to build a hardcoded map which stores project->experiment mapping. Experiment projects are passed as an array in the payload as one experiment can belong to multiple projects.