### PR TITLE
Bugfix #169012617 – Insert DOIs in `dois` column instead of PubMed IDs

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/ExperimentCrudDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/ExperimentCrudDao.java
@@ -81,7 +81,7 @@ public class ExperimentCrudDao {
                 experimentDto.isPrivate(),
                 experimentDto.getAccessKey(),
                 PUBLICATION_JOINER_OR_NULL.apply(experimentDto.getPubmedIds()),
-                PUBLICATION_JOINER_OR_NULL.apply(experimentDto.getPubmedIds()));
+                PUBLICATION_JOINER_OR_NULL.apply(experimentDto.getDois()));
     }
 
     // Read

--- a/src/test/java/uk/ac/ebi/atlas/experimentimport/ExperimentCrudDaoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentimport/ExperimentCrudDaoIT.java
@@ -188,7 +188,7 @@ class ExperimentCrudDaoIT {
         assertThat(subject.readExperiment(experimentDto.getExperimentAccession()).getPubmedIds())
                 .containsExactlyInAnyOrderElementsOf(experimentDto.getPubmedIds());
         assertThat(subject.readExperiment(experimentDto.getExperimentAccession()).getDois())
-                .containsExactlyInAnyOrderElementsOf(experimentDto.getPubmedIds());
+                .containsExactlyInAnyOrderElementsOf(experimentDto.getDois());
     }
 
     private ExperimentDto generateRandomExperimentDto() {


### PR DESCRIPTION
Insert DOIs in dois column, and test that DOIs are in the dois column (!)