### PR TITLE
- Add dropdownFilters as props to experiment table

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentInfoListService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentInfoListService.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
+import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
 import uk.ac.ebi.atlas.utils.ExperimentInfo;
 
@@ -36,21 +37,8 @@ public class ExperimentInfoListService {
 
     public JsonObject getExperimentsJson() {
         // TODO We can remove aaData when https://www.pivotaltracker.com/story/show/165720572 is done
-        var dropdownFilters = new JsonArray();
-        var projectOptions = new JsonObject();
-        var kingdomOptions = new JsonObject();
-
-        projectOptions.add("label", GSON.toJsonTree("Project"));
-        projectOptions.add("options", GSON.toJsonTree(getProjectOptions()));
-
-        kingdomOptions.add("label", GSON.toJsonTree("Kingdom"));
-        kingdomOptions.add("options", GSON.toJsonTree(getKingdomOptions()));
-
-        dropdownFilters.add(projectOptions);
-        dropdownFilters.add(kingdomOptions);
-
         JsonObject result = new JsonObject();
-        result.add("dropdownFilters", dropdownFilters);
+        result.add("dropdownFilters", getExperimentFilterDropdowns());
         result.add("aaData", GSON.toJsonTree(ImmutableMap.of("aaData", listPublicExperiments())).getAsJsonObject());
         return result;
     }
@@ -75,6 +63,41 @@ public class ExperimentInfoListService {
                 .collect(toImmutableList());
     }
 
+    private JsonArray getExperimentFilterDropdowns() {
+        var dropdownFilters = new JsonArray();
+        var projectOptions = new JsonObject();
+        var kingdomOptions = new JsonObject();
+        var technologyTypeOptions = new JsonObject();
+        var experimentTypeOptions = new JsonObject();
+
+        if(getProjectOptions().size() != 0) {
+            projectOptions.add("label", GSON.toJsonTree("Project"));
+            projectOptions.add("options", GSON.toJsonTree(getProjectOptions()));
+            dropdownFilters.add(projectOptions);
+        }
+
+        if(getKingdomOptions().size() != 0) {
+            kingdomOptions.add("label", GSON.toJsonTree("Kingdom"));
+            kingdomOptions.add("options", GSON.toJsonTree(getKingdomOptions()));
+            dropdownFilters.add(kingdomOptions);
+        }
+
+        if(getTechnologyTypeOptions().size() != 0) {
+            technologyTypeOptions.add("label", GSON.toJsonTree("Technology Type"));
+            technologyTypeOptions.add("options", GSON.toJsonTree(getTechnologyTypeOptions()));
+            dropdownFilters.add(technologyTypeOptions);
+
+        }
+
+        if(getExperimentTypeOptions().size() != 0) {
+            experimentTypeOptions.add("label", GSON.toJsonTree("Experiment Type"));
+            experimentTypeOptions.add("options", GSON.toJsonTree(getExperimentTypeOptions()));
+            dropdownFilters.add(experimentTypeOptions);
+        }
+
+        return dropdownFilters;
+    }
+
     private ImmutableList<String> getKingdomOptions() {
         return listPublicExperiments().stream()
                 .map(ExperimentInfo::getKingdom)
@@ -82,10 +105,25 @@ public class ExperimentInfoListService {
                 .collect(toImmutableList());
     }
 
+    private ImmutableList<ExperimentType> getExperimentTypeOptions() {
+        return listPublicExperiments().stream()
+                .map(ExperimentInfo::getExperimentType)
+                .distinct()
+                .collect(toImmutableList());
+    }
+
     private ImmutableList<String> getProjectOptions() {
         return  listPublicExperiments().stream()
                 .map(ExperimentInfo::getExperimentProjects)
-                .flatMap(project -> project.stream().map(option -> option))
+                .flatMap(project -> project.stream())
+                .distinct()
+                .collect(toImmutableList());
+    }
+
+    private ImmutableList<String> getTechnologyTypeOptions() {
+        return listPublicExperiments().stream()
+                .map(ExperimentInfo::getTechnologyType)
+                .flatMap(technologyType -> technologyType.stream())
                 .distinct()
                 .collect(toImmutableList());
     }

--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentInfoListService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentInfoListService.java
@@ -2,11 +2,9 @@ package uk.ac.ebi.atlas.experiments;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
-import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
 import uk.ac.ebi.atlas.utils.ExperimentInfo;
 
@@ -37,10 +35,7 @@ public class ExperimentInfoListService {
 
     public JsonObject getExperimentsJson() {
         // TODO We can remove aaData when https://www.pivotaltracker.com/story/show/165720572 is done
-        JsonObject result = new JsonObject();
-        result.add("dropdownFilters", getExperimentFilterDropdowns());
-        result.add("aaData", GSON.toJsonTree(ImmutableMap.of("aaData", listPublicExperiments())).getAsJsonObject());
-        return result;
+        return  GSON.toJsonTree(ImmutableMap.of("aaData", listPublicExperiments())).getAsJsonObject();
     }
 
     public ImmutableList<ExperimentInfo> listPublicExperiments() {
@@ -60,71 +55,6 @@ public class ExperimentInfoListService {
                                 experimentTypePrecedenceList.indexOf(experiment.getType()))
                         .thenComparing(Experiment::getDisplayName))
                 .map(Experiment::buildExperimentInfo)
-                .collect(toImmutableList());
-    }
-
-    private JsonArray getExperimentFilterDropdowns() {
-        var dropdownFilters = new JsonArray();
-        var projectOptions = new JsonObject();
-        var kingdomOptions = new JsonObject();
-        var technologyTypeOptions = new JsonObject();
-        var experimentTypeOptions = new JsonObject();
-
-        if(getProjectOptions().size() != 0) {
-            projectOptions.add("label", GSON.toJsonTree("Project"));
-            projectOptions.add("options", GSON.toJsonTree(getProjectOptions()));
-            dropdownFilters.add(projectOptions);
-        }
-
-        if(getKingdomOptions().size() != 0) {
-            kingdomOptions.add("label", GSON.toJsonTree("Kingdom"));
-            kingdomOptions.add("options", GSON.toJsonTree(getKingdomOptions()));
-            dropdownFilters.add(kingdomOptions);
-        }
-
-        if(getTechnologyTypeOptions().size() != 0) {
-            technologyTypeOptions.add("label", GSON.toJsonTree("Technology Type"));
-            technologyTypeOptions.add("options", GSON.toJsonTree(getTechnologyTypeOptions()));
-            dropdownFilters.add(technologyTypeOptions);
-
-        }
-
-        if(getExperimentTypeOptions().size() != 0) {
-            experimentTypeOptions.add("label", GSON.toJsonTree("Experiment Type"));
-            experimentTypeOptions.add("options", GSON.toJsonTree(getExperimentTypeOptions()));
-            dropdownFilters.add(experimentTypeOptions);
-        }
-
-        return dropdownFilters;
-    }
-
-    private ImmutableList<String> getKingdomOptions() {
-        return listPublicExperiments().stream()
-                .map(ExperimentInfo::getKingdom)
-                .distinct()
-                .collect(toImmutableList());
-    }
-
-    private ImmutableList<ExperimentType> getExperimentTypeOptions() {
-        return listPublicExperiments().stream()
-                .map(ExperimentInfo::getExperimentType)
-                .distinct()
-                .collect(toImmutableList());
-    }
-
-    private ImmutableList<String> getProjectOptions() {
-        return  listPublicExperiments().stream()
-                .map(ExperimentInfo::getExperimentProjects)
-                .flatMap(project -> project.stream())
-                .distinct()
-                .collect(toImmutableList());
-    }
-
-    private ImmutableList<String> getTechnologyTypeOptions() {
-        return listPublicExperiments().stream()
-                .map(ExperimentInfo::getTechnologyType)
-                .flatMap(technologyType -> technologyType.stream())
-                .distinct()
                 .collect(toImmutableList());
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/utils/ExperimentInfo.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/ExperimentInfo.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 // This class is serialised to JSON in JsonExperimentsSummaryController
 public class ExperimentInfo {
-    private ImmutableList<String> technologyType;
     private ExperimentType experimentType;
     private String experimentAccession;
     private String experimentDescription;
@@ -23,6 +22,7 @@ public class ExperimentInfo {
     private List<String> arrayDesigns = ImmutableList.of();
     private List<String> arrayDesignNames = ImmutableList.of();
     private ImmutableList<String> experimentProjects = ImmutableList.of();
+    private ImmutableList<String> technologyType = ImmutableList.of();
 
     public ExperimentType getExperimentType() {
         return experimentType;
@@ -46,6 +46,9 @@ public class ExperimentInfo {
         this.technologyType = technologyType;
         return this;
     }
+
+    public ImmutableList<String> getTechnologyType() { return this.technologyType; }
+
     public String getExperimentDescription() {
         return experimentDescription;
     }


### PR DESCRIPTION
Passing dropdownFilters in experiment payload to experiment table. Now the payload have the following structure:
```
dropdownFilters:[...],
aaData:{...}
``` 
instead of just `aaData: {...}`