### PR TITLE
Feature #169682686 – Add ZFIN IDs to the list of autocomplete suggestions

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/solr/BioentityPropertyName.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/BioentityPropertyName.java
@@ -40,7 +40,8 @@ public enum BioentityPropertyName {
     UNIPROT("uniprot", true, "UniProt", 80),
     WBPSGENE("wbpsgene", true, "WBPS gene (C. elegans, S. mansoni)", 0),
     WBPSTRANSCRIPT("wbpstranscript", true, "WBPS transcript", 0),
-    WBPSPROTEIN("wbpsprotein", true, "WBPS protein", 0);
+    WBPSPROTEIN("wbpsprotein", true, "WBPS protein", 0),
+    ZFIN_ID("zfin_id", true, "ZFIN ID", 80);
 
     private static final ImmutableMap<String, BioentityPropertyName> PROPERTIES_BY_NAME =
             ImmutableMap.copyOf(Arrays.stream(values()).collect(Collectors.toMap(v -> v.name, v -> v)));

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/BioentitiesCollectionProxy.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/BioentitiesCollectionProxy.java
@@ -7,27 +7,21 @@ import uk.ac.ebi.atlas.solr.BioentityPropertyName;
 import uk.ac.ebi.atlas.solr.cloud.CollectionProxy;
 import uk.ac.ebi.atlas.solr.cloud.SchemaField;
 
-import static uk.ac.ebi.atlas.solr.BioentityPropertyName.ENSGENE;
-import static uk.ac.ebi.atlas.solr.BioentityPropertyName.ENTREZGENE;
-import static uk.ac.ebi.atlas.solr.BioentityPropertyName.FLYBASE_GENE_ID;
-import static uk.ac.ebi.atlas.solr.BioentityPropertyName.HGNC_SYMBOL;
-import static uk.ac.ebi.atlas.solr.BioentityPropertyName.MGI_ID;
-import static uk.ac.ebi.atlas.solr.BioentityPropertyName.MGI_SYMBOL;
-import static uk.ac.ebi.atlas.solr.BioentityPropertyName.SYMBOL;
-import static uk.ac.ebi.atlas.solr.BioentityPropertyName.WBPSGENE;
+import static uk.ac.ebi.atlas.solr.BioentityPropertyName.*;
 import static uk.ac.ebi.atlas.utils.StringUtil.escapeDoubleQuotes;
 
 public class BioentitiesCollectionProxy extends CollectionProxy<BioentitiesCollectionProxy> {
     // Where, and in what order, should we search in case of a free text query (without category)
     public static final ImmutableList<BioentityPropertyName> ID_PROPERTY_NAMES =
-            ImmutableList.of(ENSGENE, SYMBOL, ENTREZGENE, HGNC_SYMBOL, MGI_ID, MGI_SYMBOL, FLYBASE_GENE_ID, WBPSGENE);
+            ImmutableList.of(
+                    ENSGENE, SYMBOL, ENTREZGENE, HGNC_SYMBOL, MGI_ID, MGI_SYMBOL, FLYBASE_GENE_ID, WBPSGENE, ZFIN_ID);
 
     // These are species-specific property names that will ignore a species argument when searching. We assume that if
     // the user chooses something like ENSG000001234 from the drop-down and Mus musculus in the species select, it is
     // because she didn’t notice and her intent is clear (or even that she chose a species but when typing and saw the
     // suggestions she changed her mind). After all, she’s the geneticist/biologist/bioinformatician!
     public static final ImmutableList<BioentityPropertyName> SPECIES_OVERRIDE_PROPERTY_NAMES =
-            ImmutableList.of(ENSGENE, ENTREZGENE, HGNC_SYMBOL, MGI_ID, MGI_SYMBOL, FLYBASE_GENE_ID, WBPSGENE);
+            ImmutableList.of(ENSGENE, ENTREZGENE, HGNC_SYMBOL, MGI_ID, MGI_SYMBOL, FLYBASE_GENE_ID, WBPSGENE, ZFIN_ID);
 
     public static final class BioentitiesSchemaField extends SchemaField<BioentitiesCollectionProxy> {
         private BioentitiesSchemaField(String fieldName) {


### PR DESCRIPTION
Add `zfin_id` in `property_name` from bioentities collection to the collection proxy object.