### PR TITLE
Read technology type in lower case from sdrf

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
@@ -36,7 +36,7 @@ public class SdrfParser {
             return technologyTypeColumnIndex > 0 ?
                     lines.stream()
                             .skip(1)
-                            .map(line -> ImmutableList.copyOf(line).get(technologyTypeColumnIndex).toLowerCase())
+                            .map(line -> ImmutableList.copyOf(line).get(technologyTypeColumnIndex).toLowerCase().trim())
                             .distinct()
                     .collect(toImmutableList()) :
                     ImmutableList.of();

--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
@@ -36,7 +36,7 @@ public class SdrfParser {
             return technologyTypeColumnIndex > 0 ?
                     lines.stream()
                             .skip(1)
-                            .map(line -> ImmutableList.copyOf(line).get(technologyTypeColumnIndex))
+                            .map(line -> ImmutableList.copyOf(line).get(technologyTypeColumnIndex).toLowerCase())
                             .distinct()
                     .collect(toImmutableList()) :
                     ImmutableList.of();

--- a/src/test/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParserTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParserTest.java
@@ -21,7 +21,8 @@ public class SdrfParserTest {
             {"Source Name", "Characteristics [organism]", "Characteristics[developmental stage]", "Characteristics [organism part]", "Factor Value[organism part]", "FactorValue [organism]", "Comment[library construction]"},
             {"first_source", "homo sapiens", "adult", "liver", "liver", "homo sapiens", "smart-seq2"},
             {"first_source", "homo sapiens", "adult", "liver", "liver", "homo sapiens", "smart-seq2"},
-            {"first_source", "homo sapiens", "adult", "liver", "liver", "homo sapiens", "smart-seq1"}
+            {"first_source", "homo sapiens", "adult", "liver", "liver", "homo sapiens", "smart-seq1"},
+            {"first_source", "homo sapiens", "adult", "liver", "liver", "homo sapiens", "Smart-seq1"}
 
     };
 


### PR DESCRIPTION
The technology type casing is inconsistent in sdrf e.g. at some places it is `Drop-seq` and at some places it is `drop-seq` because of which we were having duplicate fields in the drop.
The fix was simple I've just explicitly converted the technology type to lower case when we are reading it from the sdrf.