### PR TITLE
Bugfix #170789143 – HCA landing page links are broken

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'uk.ac.ebi.ge'
-version '3.0.0-SNAPSHOT'
+version '4.0.0-SNAPSHOT'
 
 sourceCompatibility = 11
 targetCompatibility = 11

--- a/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
@@ -30,6 +30,16 @@ public class UrlHelpers {
                 .toUriString();
     }
 
+    public static String getExperimentUrl(String host, String accession) {
+        return UriComponentsBuilder.newInstance()
+                .scheme("https")
+                .host(host)
+                .path(getApplicationContext())
+                .path("/experiments/{accession}")
+                .buildAndExpand(accession)
+                .toUriString();
+    }
+
     public static String getExperimentsFilteredBySpeciesAndExperimentType(String species, String type) {
         return UriComponentsBuilder.newInstance()
                 .path(getApplicationContext())
@@ -57,6 +67,16 @@ public class UrlHelpers {
                 .toUriString();
     }
 
+    public static String getCustomUrl(String host, String path) {
+        return UriComponentsBuilder.newInstance()
+                .scheme("https")
+                .host(host)
+                .path(getApplicationContext())
+                .path(path)
+                .build()
+                .toUriString();
+    }
+
     private static String getExperimentSetUrl(String keyword) {
         return ServletUriComponentsBuilder.fromCurrentContextPath()
                 .path("/experiments")
@@ -71,6 +91,10 @@ public class UrlHelpers {
 
     public static Pair<String, Optional<String>> getExperimentLink(String label, String accession) {
         return Pair.of(label, Optional.of(getExperimentUrl(accession)));
+    }
+
+    public static Pair<String, Optional<String>> getExperimentLink(String host, String label, String accession) {
+        return Pair.of(label, Optional.of(getExperimentUrl(host, accession)));
     }
 
     public static Pair<Optional<String>, Optional<String>> getLinkWithEmptyLabel(String link) {

--- a/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
@@ -6,6 +6,28 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import java.util.Optional;
 
 public class UrlHelpers {
+     public UrlHelpers() {
+         throw new UnsupportedOperationException();
+     }
+
+    private static String getExperimentUrl(String accession) {
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .path("/experiments/{accession}")
+                .buildAndExpand(accession)
+                .toUriString();
+    }
+
+    private static String getExperimentUrl(String host, String accession) {
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .scheme("https")
+                .host(host)
+                .path("/experiments/{accession}")
+                .buildAndExpand(accession)
+                .toUriString();
+    }
+
     public static String getExperimentsFilteredBySpeciesUrl(String species) {
         return ServletUriComponentsBuilder
                 .fromCurrentContextPath()

--- a/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
@@ -2,15 +2,13 @@ package uk.ac.ebi.atlas.utils;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import org.springframework.web.util.UriComponentsBuilder;
-import uk.ac.ebi.atlas.model.experiment.Experiment;
 
 import java.util.Optional;
 
 public class UrlHelpers {
     public static String getExperimentsFilteredBySpeciesUrl(String species) {
-        return UriComponentsBuilder.newInstance()
-                .path(getApplicationContext())
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
                 .path("/experiments")
                 .query("species={species}")
                 .buildAndExpand(species)
@@ -18,31 +16,9 @@ public class UrlHelpers {
                 .toUriString();
     }
 
-    public static String getExperimentUrl(Experiment experiment) {
-        return getExperimentUrl(experiment.getAccession());
-    }
-
-    public static String getExperimentUrl(String accession) {
-        return UriComponentsBuilder.newInstance()
-                .path(getApplicationContext())
-                .path("/experiments/{accession}")
-                .buildAndExpand(accession)
-                .toUriString();
-    }
-
-    public static String getExperimentUrl(String host, String accession) {
-        return UriComponentsBuilder.newInstance()
-                .scheme("https")
-                .host(host)
-                .path(getApplicationContext())
-                .path("/experiments/{accession}")
-                .buildAndExpand(accession)
-                .toUriString();
-    }
-
     public static String getExperimentsFilteredBySpeciesAndExperimentType(String species, String type) {
-        return UriComponentsBuilder.newInstance()
-                .path(getApplicationContext())
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
                 .path("/experiments")
                 .query("species={species}")
                 .query("experimentType={type}")
@@ -52,33 +28,34 @@ public class UrlHelpers {
     }
 
     public static String getExperimentsSummaryImageUrl(String imageFileName) {
-        return UriComponentsBuilder.newInstance()
-                .path(getApplicationContext())
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
                 .path("/resources/images/experiments-summary/{imageFileName}.png")
                 .buildAndExpand(imageFileName)
                 .toUriString();
     }
 
     public static String getCustomUrl(String path) {
-        return UriComponentsBuilder.newInstance()
-                .path(getApplicationContext())
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
                 .path(path)
                 .build()
                 .toUriString();
     }
 
     public static String getCustomUrl(String host, String path) {
-        return UriComponentsBuilder.newInstance()
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
                 .scheme("https")
                 .host(host)
-                .path(getApplicationContext())
                 .path(path)
                 .build()
                 .toUriString();
     }
 
     private static String getExperimentSetUrl(String keyword) {
-        return ServletUriComponentsBuilder.fromCurrentContextPath()
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
                 .path("/experiments")
                 .query("experimentSet={keyword}")
                 .buildAndExpand(keyword)
@@ -103,9 +80,5 @@ public class UrlHelpers {
 
     public static Pair<Optional<String>, Optional<String>> getExperimentLink(String accession) {
         return getLinkWithEmptyLabel(getExperimentUrl(accession));
-    }
-
-    private static String getApplicationContext() {
-        return Optional.ofNullable(ServletUriComponentsBuilder.fromCurrentContextPath().build().getPath()).orElse("");
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
+++ b/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.web.client.RestTemplate;
 import uk.ac.ebi.atlas.trader.ExperimentRepository;
-import uk.ac.ebi.atlas.utils.UrlHelpers;
 
 @Configuration
 // Enabling component scanning will also load BasePathsConfig, JdbcConfig and SolrConfig, so just using this class as
@@ -19,11 +18,6 @@ public class TestConfig {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
-    }
-
-    @Bean
-    public UrlHelpers urlHelpers() {
-        return new UrlHelpers() {};
     }
 
     @Bean

--- a/src/test/java/uk/ac/ebi/atlas/utils/UrlHelpersIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/utils/UrlHelpersIT.java
@@ -1,89 +1,87 @@
 package uk.ac.ebi.atlas.utils;
 
-import com.google.common.net.UrlEscapers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import uk.ac.ebi.atlas.configuration.TestConfig;
-import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomSpecies;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomUrl;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getCustomUrl;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getExperimentLink;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getExperimentSetLink;
-import static uk.ac.ebi.atlas.utils.UrlHelpers.getExperimentUrl;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getExperimentsFilteredBySpeciesAndExperimentType;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getExperimentsFilteredBySpeciesUrl;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getExperimentsSummaryImageUrl;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getLinkWithEmptyLabel;
 
-@ExtendWith({SpringExtension.class, MockitoExtension.class})
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
 class UrlHelpersIT {
     private static final ThreadLocalRandom RNG = ThreadLocalRandom.current();
-    private static final String ORIGIN = "https://foobar.com";
-
-    @Mock
-    Experiment experimentMock;
 
     @Test
-    void speciesUrl() throws MalformedURLException {
+    void utilityClass() {
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(UrlHelpers::new);
+    }
+
+    @Test
+    void speciesUrl() throws Exception {
         var species = generateRandomSpecies();
 
-        assertThat(new URL(ORIGIN + getExperimentsFilteredBySpeciesUrl(species.getReferenceName())))
+        assertThat(new URL(getExperimentsFilteredBySpeciesUrl(species.getReferenceName())))
                 .hasPath("/experiments")
                 .hasParameter("species", species.getReferenceName());
     }
 
     @Test
-    void experimentUrl() throws MalformedURLException {
-        var experimentAccession = generateRandomExperimentAccession();
-        when(experimentMock.getAccession()).thenReturn(experimentAccession);
-
-        assertThat(new URL(ORIGIN + getExperimentUrl(experimentMock)))
-                .hasPath("/experiments/" + UrlEscapers.urlPathSegmentEscaper().escape(experimentAccession));
-    }
-
-    @Test
-    void speciesAndTypeUrl() throws MalformedURLException {
+    void speciesAndTypeUrl() throws Exception {
         var species = generateRandomSpecies();
         var type = ExperimentType.values()[RNG.nextInt(ExperimentType.values().length)];
 
-        assertThat(new URL(ORIGIN + getExperimentsFilteredBySpeciesAndExperimentType(species.getReferenceName(), type.name())))
+        assertThat(new URL(getExperimentsFilteredBySpeciesAndExperimentType(species.getReferenceName(), type.name())))
                 .hasPath("/experiments")
                 .hasParameter("species", species.getReferenceName())
                 .hasParameter("experimentType", type.name());
     }
 
     @Test
-    void imageUrl() throws MalformedURLException {
+    void imageUrl() throws Exception {
         var imageFileName = randomAlphabetic(5, 20);
 
-        assertThat(new URL(ORIGIN + getExperimentsSummaryImageUrl(imageFileName)))
+        assertThat(new URL(getExperimentsSummaryImageUrl(imageFileName)))
                 .hasPath("/resources/images/experiments-summary/" + imageFileName + ".png");
     }
 
     @Test
-    void customUrl() throws MalformedURLException {
+    void customUrl() throws Exception {
         var path = "/" + randomAlphabetic(5, 20);
 
-        assertThat(new URL(ORIGIN + getCustomUrl(path)))
+        assertThat(new URL(getCustomUrl(path)))
+                .hasPath(path);
+    }
+
+    @Test
+    void fullyQualifiedCustomUrl() throws Exception {
+        var path = "/" + randomAlphabetic(5, 20);
+        var host = new URL(generateRandomUrl()).getHost();
+
+        assertThat(new URL(getCustomUrl(host, path)))
+                .hasProtocol("https")
+                .hasHost(host)
                 .hasPath(path);
     }
 
@@ -98,42 +96,51 @@ class UrlHelpersIT {
 
 
     @Test
-    void experimentSetLink() {
+    void experimentSetLink() throws Exception {
         var keyword = randomAlphabetic(3, 5);
 
         var result = getExperimentSetLink(keyword);
         assertThat(result.getLeft())
                 .isEmpty();
-        assertThat(result.getRight())
-                .get()
-                .asString()
-                .contains("?experimentSet=" + keyword);
+        assertThat(new URL(result.getRight().get()))
+                .hasParameter("experimentSet", keyword);
     }
 
     @Test
-    void experimentLink() {
+    void experimentLink() throws Exception {
         var experimentAccession = generateRandomExperimentAccession();
         var label = randomAlphabetic(3, 20);
 
         var result = getExperimentLink(label, experimentAccession);
         assertThat(result.getLeft())
                 .isEqualTo(label);
-        assertThat(result.getRight())
-                .get()
-                .asString()
-                .contains("/experiments/" + experimentAccession);
+        assertThat(new URL(result.getRight().get()))
+                .hasPath("/experiments/" + experimentAccession);
     }
 
     @Test
-    void labelInExperimentLinkCanBeOmitted() {
+    void fullyQualifiedExperimentLink() throws Exception {
+        var experimentAccession = generateRandomExperimentAccession();
+        var label = randomAlphabetic(3, 20);
+        var host = new URL(generateRandomUrl()).getHost();
+
+        var result = getExperimentLink(host, label, experimentAccession);
+        assertThat(result.getLeft())
+                .isEqualTo(label);
+        assertThat(new URL(result.getRight().get()))
+                .hasProtocol("https")
+                .hasHost(host)
+                .hasPath("/experiments/" + experimentAccession);
+    }
+
+    @Test
+    void labelInExperimentLinkCanBeOmitted() throws Exception {
         var experimentAccession = generateRandomExperimentAccession();
 
         var result = getExperimentLink(experimentAccession);
         assertThat(result.getLeft())
                 .isEmpty();
-        assertThat(result.getRight())
-                .get()
-                .asString()
-                .contains("/experiments/" + experimentAccession);
+        assertThat(new URL(result.getRight().get()))
+                .hasPath("/experiments/" + experimentAccession);
     }
 }


### PR DESCRIPTION
We were passing relative links to the HCA landing page (e.g. `/gxa/sc/experiments/E-EHCA-1`) which were then resolved against the local domain (`ebi-gene-expression-team.github.io`), which of course resulted in broken links.

I’ve added additional methods to `UrlHelpers` to which you can pass a `host` argument so that they return a fully qualified URL (e.g. `https://www.ebi.ac.uk/gxa/sc/...`). I took the chance to clean the class itself and its tests.