### PR TITLE
Implement Unique and Reduce solr stream operation

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/ReducerStreamBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/ReducerStreamBuilder.java
@@ -1,0 +1,36 @@
+package uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.decorator;
+
+import org.apache.solr.client.solrj.io.comp.ComparatorOrder;
+import org.apache.solr.client.solrj.io.comp.FieldComparator;
+import org.apache.solr.client.solrj.io.ops.GroupOperation;
+import org.apache.solr.client.solrj.io.stream.ReducerStream;
+import org.apache.solr.client.solrj.io.stream.TupleStream;
+import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.TupleStreamBuilder;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public class ReducerStreamBuilder extends TupleStreamBuilder {
+    private final TupleStreamBuilder tupleStreamBuilder;
+    private final String fieldName;
+    private final int groupBySize;
+
+    public ReducerStreamBuilder(TupleStreamBuilder tupleStreamBuilder, String fieldName, int groupBySize) {
+        this.tupleStreamBuilder = tupleStreamBuilder;
+        this.fieldName = fieldName;
+        this.groupBySize = groupBySize;
+    }
+
+    @Override
+    protected TupleStream getRawTupleStream() {
+        try {
+            var fieldComparator = new FieldComparator(fieldName, ComparatorOrder.ASCENDING);
+            return new ReducerStream(
+                    tupleStreamBuilder.build(),
+                    fieldComparator,
+                    new GroupOperation(fieldComparator, groupBySize));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/ReducerStreamBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/ReducerStreamBuilder.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.decorator;
 
 import org.apache.solr.client.solrj.io.comp.ComparatorOrder;
 import org.apache.solr.client.solrj.io.comp.FieldComparator;
+import org.apache.solr.client.solrj.io.eq.FieldEqualitor;
 import org.apache.solr.client.solrj.io.ops.GroupOperation;
 import org.apache.solr.client.solrj.io.stream.ReducerStream;
 import org.apache.solr.client.solrj.io.stream.TupleStream;
@@ -12,23 +13,29 @@ import java.io.UncheckedIOException;
 
 public class ReducerStreamBuilder extends TupleStreamBuilder {
     private final TupleStreamBuilder tupleStreamBuilder;
-    private final String fieldName;
+    private final String reduceByFieldName;
+    private final String groupByFieldName;
     private final int groupBySize;
 
-    public ReducerStreamBuilder(TupleStreamBuilder tupleStreamBuilder, String fieldName, int groupBySize) {
+    public ReducerStreamBuilder(
+            TupleStreamBuilder tupleStreamBuilder,
+            String reduceByFieldName,
+            String groupByFieldName,
+            int groupBySize) {
         this.tupleStreamBuilder = tupleStreamBuilder;
-        this.fieldName = fieldName;
+        this.reduceByFieldName = reduceByFieldName;
+        this.groupByFieldName = groupByFieldName;
         this.groupBySize = groupBySize;
     }
 
     @Override
     protected TupleStream getRawTupleStream() {
         try {
-            var fieldComparator = new FieldComparator(fieldName, ComparatorOrder.ASCENDING);
+            var groupByFieldComparator = new FieldComparator(groupByFieldName, ComparatorOrder.ASCENDING);
             return new ReducerStream(
                     tupleStreamBuilder.build(),
-                    fieldComparator,
-                    new GroupOperation(fieldComparator, groupBySize));
+                    new FieldEqualitor(reduceByFieldName),
+                    new GroupOperation(groupByFieldComparator, groupBySize));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/UniqueStreamBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/UniqueStreamBuilder.java
@@ -1,0 +1,30 @@
+package uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.decorator;
+
+import org.apache.solr.client.solrj.io.eq.FieldEqualitor;
+import org.apache.solr.client.solrj.io.stream.TupleStream;
+import org.apache.solr.client.solrj.io.stream.UniqueStream;
+import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.TupleStreamBuilder;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public class UniqueStreamBuilder extends TupleStreamBuilder {
+    private final TupleStreamBuilder tupleStreamBuilder;
+    private final String overField;
+
+    public UniqueStreamBuilder(TupleStreamBuilder tupleStreamBuilder, String fieldName) {
+        this.tupleStreamBuilder = tupleStreamBuilder;
+        this.overField = fieldName;
+    }
+
+    @Override
+    protected TupleStream getRawTupleStream() {
+        try {
+            return new UniqueStream(
+                    tupleStreamBuilder.build(),
+                    new FieldEqualitor(overField));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/ReducerStreamBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/ReducerStreamBuilderTest.java
@@ -1,0 +1,56 @@
+package uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.decorator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.io.Tuple;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.atlas.solr.cloud.CollectionProxy;
+import uk.ac.ebi.atlas.solr.cloud.TupleStreamer;
+import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.DummyTupleStreamBuilder;
+import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.TupleStreamBuilder;
+
+import java.io.UncheckedIOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class ReducerStreamBuilderTest {
+    private class DummyCollectionProxy extends CollectionProxy {
+        protected DummyCollectionProxy(SolrClient solrClient, String nameOrAlias) {
+            super(solrClient, nameOrAlias);
+        }
+    }
+
+    private static final String SORT_FIELD = "field1";
+
+    private List<Tuple> streamA = ImmutableList.of(
+            new Tuple(ImmutableMap.of(SORT_FIELD, "a", "field2", "a")),
+            new Tuple(ImmutableMap.of(SORT_FIELD, "a", "field2", "b")),
+            new Tuple(ImmutableMap.of(SORT_FIELD, "a", "field2", "c")),
+            new Tuple(ImmutableMap.of(SORT_FIELD, "b", "field2", "d")),
+            new Tuple(ImmutableMap.of(SORT_FIELD, "b", "field2", "e")),
+            new Tuple(ImmutableMap.of(SORT_FIELD, "b", "field2", "f")),
+            new Tuple(ImmutableMap.of(SORT_FIELD, "c", "field2", "g")),
+            new Tuple(ImmutableMap.of(SORT_FIELD, "c", "field2", "h")),
+            new Tuple(ImmutableMap.of(SORT_FIELD, "c", "field2", "i")),
+            new Tuple(ImmutableMap.of(SORT_FIELD, "c", "field2", "j")));
+
+
+    private TupleStreamBuilder<ReducerStreamBuilderTest.DummyCollectionProxy> tupleStreamBuilderA =
+            DummyTupleStreamBuilder.create(streamA, SORT_FIELD, true);
+
+    @Test
+    void throwExceptionIfGivenFieldIsNotSortField() {
+        var subject = new ReducerStreamBuilder(tupleStreamBuilderA, "field2", 10);
+        assertThatExceptionOfType(UncheckedIOException.class)
+                        .isThrownBy(() -> TupleStreamer.of(subject.build()).get());
+    }
+
+    @Test
+    void returnsReducedStreamForGivenSortField() {
+        var subject = new ReducerStreamBuilder(tupleStreamBuilderA, SORT_FIELD, 10);
+        assertThat(TupleStreamer.of(subject.build()).get()).hasSize(3);
+    }
+}

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/ReducerStreamBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/ReducerStreamBuilderTest.java
@@ -22,7 +22,6 @@ class ReducerStreamBuilderTest {
             super(solrClient, nameOrAlias);
         }
     }
-
     private static final String SORT_FIELD = "field1";
 
     private List<Tuple> streamA = ImmutableList.of(
@@ -37,20 +36,19 @@ class ReducerStreamBuilderTest {
             new Tuple(ImmutableMap.of(SORT_FIELD, "c", "field2", "i")),
             new Tuple(ImmutableMap.of(SORT_FIELD, "c", "field2", "j")));
 
-
     private TupleStreamBuilder<ReducerStreamBuilderTest.DummyCollectionProxy> tupleStreamBuilderA =
             DummyTupleStreamBuilder.create(streamA, SORT_FIELD, true);
 
     @Test
     void throwExceptionIfGivenFieldIsNotSortField() {
-        var subject = new ReducerStreamBuilder(tupleStreamBuilderA, "field2", 10);
+        var subject = new ReducerStreamBuilder(tupleStreamBuilderA, "field2", SORT_FIELD, 10);
         assertThatExceptionOfType(UncheckedIOException.class)
                         .isThrownBy(() -> TupleStreamer.of(subject.build()).get());
     }
 
     @Test
     void returnsReducedStreamForGivenSortField() {
-        var subject = new ReducerStreamBuilder(tupleStreamBuilderA, SORT_FIELD, 10);
+        var subject = new ReducerStreamBuilder(tupleStreamBuilderA, SORT_FIELD, "field2",10);
         assertThat(TupleStreamer.of(subject.build()).get()).hasSize(3);
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/UniqueStreamBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/UniqueStreamBuilderTest.java
@@ -1,0 +1,57 @@
+package uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.decorator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.io.Tuple;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.atlas.solr.cloud.CollectionProxy;
+import uk.ac.ebi.atlas.solr.cloud.TupleStreamer;
+import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.DummyTupleStreamBuilder;
+import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.TupleStreamBuilder;
+
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class UniqueStreamBuilderTest {
+    private class DummyCollectionProxy extends CollectionProxy {
+        protected DummyCollectionProxy(SolrClient solrClient, String nameOrAlias) {
+            super(solrClient, nameOrAlias);
+        }
+    }
+
+    private static final String SORT_FIELD = "id";
+
+    private List<Map<String, String>> streamA = ImmutableList.of(
+            ImmutableMap.of(SORT_FIELD, "a", "fieldA", "x"),
+            ImmutableMap.of(SORT_FIELD, "a", "fieldA", "x"),
+            ImmutableMap.of(SORT_FIELD, "b", "fieldA", "y"),
+            ImmutableMap.of(SORT_FIELD, "b", "fieldA", "y"),
+            ImmutableMap.of(SORT_FIELD, "c", "fieldA", "z"),
+            ImmutableMap.of(SORT_FIELD, "c", "fieldA", "z"));
+
+
+    private TupleStreamBuilder<DummyCollectionProxy> tupleStreamBuilderA =
+            DummyTupleStreamBuilder.create(streamA.stream().map(Tuple::new).collect(toList()), SORT_FIELD, true);
+
+
+    @Test
+    void returnsUniqueStreamForGivenField() {
+        var subject = new UniqueStreamBuilder(tupleStreamBuilderA, SORT_FIELD);
+        assertThat(TupleStreamer.of(subject.build()).get().collect(toList()))
+                .hasSize(3);
+
+    }
+
+    @Test
+    void throwExceptionIfGivenFieldIsNotSortField() {
+        var subject = new UniqueStreamBuilder(tupleStreamBuilderA, "fieldB");
+        assertThatExceptionOfType(UncheckedIOException.class)
+                .isThrownBy(() -> TupleStreamer.of(subject.build()).get());
+    }
+}

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/UniqueStreamBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/UniqueStreamBuilderTest.java
@@ -24,7 +24,6 @@ class UniqueStreamBuilderTest {
             super(solrClient, nameOrAlias);
         }
     }
-
     private static final String SORT_FIELD = "id";
 
     private List<Map<String, String>> streamA = ImmutableList.of(
@@ -35,17 +34,14 @@ class UniqueStreamBuilderTest {
             ImmutableMap.of(SORT_FIELD, "c", "fieldA", "z"),
             ImmutableMap.of(SORT_FIELD, "c", "fieldA", "z"));
 
-
     private TupleStreamBuilder<DummyCollectionProxy> tupleStreamBuilderA =
             DummyTupleStreamBuilder.create(streamA.stream().map(Tuple::new).collect(toList()), SORT_FIELD, true);
-
 
     @Test
     void returnsUniqueStreamForGivenField() {
         var subject = new UniqueStreamBuilder(tupleStreamBuilderA, SORT_FIELD);
         assertThat(TupleStreamer.of(subject.build()).get().collect(toList()))
                 .hasSize(3);
-
     }
 
     @Test


### PR DESCRIPTION
To retrieve human experiments and their related organism part from solr we need following stream query.

https://ebi-fg.slack.com/archives/C9P2QETJ9/p1574262157019100

In our code we already had implementation of varios stream operation but `unique` and `reduce` were missing which I implemented in this PR.
