### PR TITLE
Modify organism part endpoint

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentJsonService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentJsonService.java
@@ -11,7 +11,6 @@ import uk.ac.ebi.atlas.trader.ExperimentTrader;
 import java.util.Comparator;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL;
 import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL;
 import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL;
@@ -50,21 +49,5 @@ public class ExperimentJsonService {
                         .thenComparing(Experiment::getDisplayName))
                 .map(ExperimentJsonSerializer::serialize)
                 .collect(toImmutableSet());
-    }
-
-    public ImmutableSet<JsonObject> getPublicExperimentsJson(String characteristicName, String characteristicValue) {
-        if (isBlank(characteristicName) || isBlank(characteristicValue)) {
-            return getPublicExperimentsJson();
-        } else {
-            // Sort by experiment type according to the above precedence list and then by display name
-            return experimentTrader.getPublicExperiments(characteristicName, characteristicValue)
-                    .stream()
-                    .sorted(Comparator
-                            .<Experiment>comparingInt(experiment ->
-                                    EXPERIMENT_TYPE_PRECEDENCE_LIST.indexOf(experiment.getType()))
-                            .thenComparing(Experiment::getDisplayName))
-                    .map(ExperimentJsonSerializer::serialize)
-                    .collect(toImmutableSet());
-        }
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/SingleCellAnalyticsCollectionProxy.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/SingleCellAnalyticsCollectionProxy.java
@@ -24,6 +24,14 @@ public class SingleCellAnalyticsCollectionProxy extends CollectionProxy<SingleCe
             new SingleCellAnalyticsSchemaField("characteristic_name");
     public static final SingleCellAnalyticsSchemaField CHARACTERISTIC_VALUE =
             new SingleCellAnalyticsSchemaField("characteristic_value");
+    public static final SingleCellAnalyticsSchemaField ONTOLOGY_ANNOTATION_ANCESTORS_URIS =
+            new SingleCellAnalyticsSchemaField("ontology_annotation_ancestors_uris_s");
+    public static final SingleCellAnalyticsSchemaField ONTOLOGY_ANNOTATION =
+            new SingleCellAnalyticsSchemaField("ontology_annotation");
+    public static final SingleCellAnalyticsSchemaField ONTOLOGY_ANNOTATION_LABEL =
+            new SingleCellAnalyticsSchemaField("ontology_annotation_label_t");
+    public static final SingleCellAnalyticsSchemaField ONTOLOGY_ANNOTATION_ANCESTORS_LABELS =
+            new SingleCellAnalyticsSchemaField("ontology_annotation_ancestors_labels_t");
 
     public SingleCellAnalyticsCollectionProxy(SolrClient solrClient) {
         // scxa-analytics is an alias that points at scxa-analytics-vX

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
@@ -34,9 +34,10 @@ public class SolrQueryBuilder<T extends CollectionProxy> {
     private SolrJsonFacetBuilder<T> facetBuilder;
 
     private int rows = DEFAULT_ROWS;
+    private boolean normalize = true;
 
     public <U extends SchemaField<T>> SolrQueryBuilder<T> addFilterFieldByTerm(U field, Collection<String> values) {
-        fqClausesBuilder.add(createOrBooleanQuery(field, values));
+        fqClausesBuilder.add(createOrBooleanQuery(field, values, normalize));
         return this;
     }
 
@@ -63,7 +64,7 @@ public class SolrQueryBuilder<T extends CollectionProxy> {
     }
 
     public <U extends SchemaField<T>> SolrQueryBuilder<T> addQueryFieldByTerm(U field, Collection<String> values) {
-        qClausesBuilder.add(createOrBooleanQuery(field, values));
+        qClausesBuilder.add(createOrBooleanQuery(field, values, normalize));
         return this;
     }
 
@@ -72,7 +73,7 @@ public class SolrQueryBuilder<T extends CollectionProxy> {
         String clause = fieldsAndValues
                 .entrySet()
                 .stream()
-                .map(fieldAndValue -> createOrBooleanQuery(fieldAndValue.getKey(), fieldAndValue.getValue()))
+                .map(fieldAndValue -> createOrBooleanQuery(fieldAndValue.getKey(), fieldAndValue.getValue(), normalize))
                 .collect(joining(" OR "));
 
         qClausesBuilder.add("(" + clause + ")");
@@ -107,6 +108,11 @@ public class SolrQueryBuilder<T extends CollectionProxy> {
 
     public SolrQueryBuilder<T> setFacets(SolrJsonFacetBuilder<T> facetBuilder) {
         this.facetBuilder = facetBuilder;
+        return this;
+    }
+
+    public SolrQueryBuilder<T> setNormalize(boolean normalize) {
+        this.normalize = normalize;
         return this;
     }
 

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryUtils.java
@@ -29,13 +29,17 @@ public class SolrQueryUtils {
     }
 
     public static String createOrBooleanQuery(SchemaField field, Collection<String> values) {
+        return createOrBooleanQuery(field, values, true);
+    }
+
+    public static String createOrBooleanQuery(SchemaField field, Collection<String> values, boolean normalize) {
         return values.stream().anyMatch(StringUtils::isNotBlank) ?
                 String.format(
                         STANDARD_QUERY_PARSER_FIELD_QUERY_TEMPLATE,
                         field.name(),
                         values.stream()
                                 .filter(StringUtils::isNotBlank)
-                                .map(SolrQueryUtils::normalize)
+                                .map(value -> normalize ? SolrQueryUtils.normalize(value) : value)
                                 .distinct()
                                 .collect(joining(" OR "))) :
                 String.format(STANDARD_QUERY_PARSER_EXCLUDE_FIELD_QUERY_TEMPLATE, field.name());

--- a/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTrader.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTrader.java
@@ -58,10 +58,4 @@ public class ExperimentTrader {
                 .map(this::getPublicExperiment)
                 .collect(toImmutableSet());
     }
-
-    public ImmutableSet<Experiment> getPublicExperiments(String characteristicName, String characteristicValue) {
-        return experimentTraderDao.fetchPublicExperimentAccessions(characteristicName, characteristicValue).stream()
-                .map(this::getPublicExperiment)
-                .collect(toImmutableSet());
-    }
 }

--- a/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTraderDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTraderDao.java
@@ -2,33 +2,19 @@ package uk.ac.ebi.atlas.trader;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
-import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
-import uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy;
-import uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder;
-
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-
-import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.CHARACTERISTIC_NAME;
-import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.CHARACTERISTIC_VALUE;
-import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.EXPERIMENT_ACCESSION;
 
 @Component
 public class ExperimentTraderDao {
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
-    private final SingleCellAnalyticsCollectionProxy singleCellAnalyticsCollectionProxy;
 
-    public ExperimentTraderDao(NamedParameterJdbcTemplate namedParameterJdbcTemplate,
-                               SolrCloudCollectionProxyFactory solrCloudCollectionProxyFactory) {
+    public ExperimentTraderDao(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
         this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
-        this.singleCellAnalyticsCollectionProxy = solrCloudCollectionProxyFactory.create(SingleCellAnalyticsCollectionProxy.class);
     }
 
     public ImmutableSet<String> fetchPublicExperimentAccessions(ExperimentType... experimentTypes) {
@@ -42,19 +28,5 @@ public class ExperimentTraderDao {
                         "SELECT accession FROM experiment WHERE private=FALSE AND type IN(:experimentTypes)",
                         ImmutableMap.of("experimentTypes", experimentTypeNames),
                         String.class));
-    }
-
-    public ImmutableSet<String> fetchPublicExperimentAccessions(String characteristicName, String characteristicValue) {
-        var queryBuilder =
-                new SolrQueryBuilder<SingleCellAnalyticsCollectionProxy>()
-                          .addQueryFieldByTerm(CHARACTERISTIC_NAME, characteristicName)
-                          .addQueryFieldByTerm(CHARACTERISTIC_VALUE, characteristicValue)
-                          .setFieldList(EXPERIMENT_ACCESSION);
-
-        var results = this.singleCellAnalyticsCollectionProxy.query(queryBuilder).getResults();
-        return results
-                .stream()
-                .map(solrDocument -> (String) solrDocument.getFieldValue(EXPERIMENT_ACCESSION.name()))
-                .collect(toImmutableSet());
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonServiceTest.java
@@ -27,35 +27,12 @@ public class ExperimentJsonServiceTest {
         when(experimentTraderMock.getPublicExperiments())
                 .thenReturn(ImmutableSet.of(MockExperiment.createBaselineExperiment(EXPERIMENT_ACCESSION)));
 
-        when(experimentTraderMock.getPublicExperiments("sex", "female"))
-                .thenReturn(ImmutableSet.of(MockExperiment.createBaselineExperiment(EXPERIMENT_ACCESSION)));
-
         subject = new ExperimentJsonService(experimentTraderMock);
     }
 
     @Test
     public void sizeIsRightForNonParameterisedExperimentJsonMethod() {
         assertThat(subject.getPublicExperimentsJson()).hasSize(1);
-    }
-
-    @Test
-    public void sizeIsRightForCorrectCharacteristicNameAndCharacteristicValue() {
-        assertThat(subject.getPublicExperimentsJson("sex","female")).hasSize(1);
-    }
-
-    @Test
-    public void sizeIsRightForEmptyCharacteristicName() {
-        assertThat(subject.getPublicExperimentsJson("", "female")).hasSize(1);
-    }
-
-    @Test
-    public void sizeIsRightForEmptyCharacteristicValueJsonMethod() {
-        assertThat(subject.getPublicExperimentsJson("sex", "")).hasSize(1);
-    }
-
-    @Test
-    public void sizeIsRightForEmptyCharacteristicNameAndCharacteristicValue() {
-        assertThat(subject.getPublicExperimentsJson("", "")).hasSize(1);
     }
 
     @Test
@@ -76,59 +53,8 @@ public class ExperimentJsonServiceTest {
     }
 
     @Test
-    public void formatIsAsExpectedForCorrectCharacteristicNameAndValue() {
-        var result = subject.getPublicExperimentsJson("sex","female").iterator().next();
-
-        assertThat(result.get("experimentType").getAsString()).isEqualTo("Baseline");
-        assertThat(result.get("experimentAccession").getAsString()).isEqualToIgnoringCase(EXPERIMENT_ACCESSION);
-        assertThat(result.get("experimentDescription").getAsString()).isNotEmpty();
-        assertThat(result.get("loadDate").getAsString()).isNotEmpty();
-        assertThat(result.get("lastUpdate").getAsString()).isNotEmpty();
-        assertThat(result.get("numberOfAssays").getAsInt()).isGreaterThan(0);
-
-        assertThat(result.get("species").getAsString()).isNotEmpty();
-        assertThat(result.get("kingdom").getAsString()).isNotEmpty();
-
-        assertThat(result.has("experimentalFactors")).isTrue();
-    }
-
-    @Test
     public void formatIsAsExpectedForEmptyCharacteristicName() {
         var result = subject.getPublicExperimentsJson().iterator().next();
-
-        assertThat(result.get("experimentType").getAsString()).isEqualTo("Baseline");
-        assertThat(result.get("experimentAccession").getAsString()).isEqualToIgnoringCase(EXPERIMENT_ACCESSION);
-        assertThat(result.get("experimentDescription").getAsString()).isNotEmpty();
-        assertThat(result.get("loadDate").getAsString()).isNotEmpty();
-        assertThat(result.get("lastUpdate").getAsString()).isNotEmpty();
-        assertThat(result.get("numberOfAssays").getAsInt()).isGreaterThan(0);
-
-        assertThat(result.get("species").getAsString()).isNotEmpty();
-        assertThat(result.get("kingdom").getAsString()).isNotEmpty();
-
-        assertThat(result.has("experimentalFactors")).isTrue();
-    }
-
-    @Test
-    public void formatIsAsExpectedForEmptyCharacteristicValue() {
-        var result = subject.getPublicExperimentsJson("sex","").iterator().next();
-
-        assertThat(result.get("experimentType").getAsString()).isEqualTo("Baseline");
-        assertThat(result.get("experimentAccession").getAsString()).isEqualToIgnoringCase(EXPERIMENT_ACCESSION);
-        assertThat(result.get("experimentDescription").getAsString()).isNotEmpty();
-        assertThat(result.get("loadDate").getAsString()).isNotEmpty();
-        assertThat(result.get("lastUpdate").getAsString()).isNotEmpty();
-        assertThat(result.get("numberOfAssays").getAsInt()).isGreaterThan(0);
-
-        assertThat(result.get("species").getAsString()).isNotEmpty();
-        assertThat(result.get("kingdom").getAsString()).isNotEmpty();
-
-        assertThat(result.has("experimentalFactors")).isTrue();
-    }
-
-    @Test
-    public void formatIsAsExpectedForEmptyCharacteristicNameAndValue() {
-        var result = subject.getPublicExperimentsJson("","").iterator().next();
 
         assertThat(result.get("experimentType").getAsString()).isEqualTo("Baseline");
         assertThat(result.get("experimentAccession").getAsString()).isEqualToIgnoringCase(EXPERIMENT_ACCESSION);

--- a/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonServiceTest.java
@@ -51,21 +51,4 @@ public class ExperimentJsonServiceTest {
 
         assertThat(result.has("experimentalFactors")).isTrue();
     }
-
-    @Test
-    public void formatIsAsExpectedForEmptyCharacteristicName() {
-        var result = subject.getPublicExperimentsJson().iterator().next();
-
-        assertThat(result.get("experimentType").getAsString()).isEqualTo("Baseline");
-        assertThat(result.get("experimentAccession").getAsString()).isEqualToIgnoringCase(EXPERIMENT_ACCESSION);
-        assertThat(result.get("experimentDescription").getAsString()).isNotEmpty();
-        assertThat(result.get("loadDate").getAsString()).isNotEmpty();
-        assertThat(result.get("lastUpdate").getAsString()).isNotEmpty();
-        assertThat(result.get("numberOfAssays").getAsInt()).isGreaterThan(0);
-
-        assertThat(result.get("species").getAsString()).isNotEmpty();
-        assertThat(result.get("kingdom").getAsString()).isNotEmpty();
-
-        assertThat(result.has("experimentalFactors")).isTrue();
-    }
 }

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilderTest.java
@@ -149,4 +149,25 @@ class SolrQueryBuilderTest {
 
         assertThat(result).isNotEmpty();
     }
+
+    @Test
+    void queryIsNotNormalizedWhenFlagSetToFalse() {
+        SolrQuery solrQuery =
+                new SolrQueryBuilder<>()
+                        .setNormalize(false)
+                        .addQueryFieldByTerm(FIELD1, "*value1")
+                        .build();
+
+        assertThat(solrQuery.getQuery()).isEqualTo(FIELD1.name() + ":(*value1)");
+    }
+
+    @Test
+    void queryIsNormalizedByDefault() {
+        SolrQuery solrQuery =
+                new SolrQueryBuilder<>()
+                        .addQueryFieldByTerm(FIELD1, "*value1")
+                        .build();
+
+        assertThat(solrQuery.getQuery()).isEqualTo(FIELD1.name() + ":(\"\\*value1\")");
+    }
 }

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilderTest.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder.SOLR_MAX_ROWS;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
@@ -152,22 +153,24 @@ class SolrQueryBuilderTest {
 
     @Test
     void queryIsNotNormalizedWhenFlagSetToFalse() {
+        var fieldValue = "*" + randomAlphabetic(10);
         SolrQuery solrQuery =
                 new SolrQueryBuilder<>()
                         .setNormalize(false)
-                        .addQueryFieldByTerm(FIELD1, "*value1")
+                        .addQueryFieldByTerm(FIELD1, fieldValue)
                         .build();
 
-        assertThat(solrQuery.getQuery()).isEqualTo(FIELD1.name() + ":(*value1)");
+        assertThat(solrQuery.getQuery()).isEqualTo(FIELD1.name() + ":(" + fieldValue + ")");
     }
 
     @Test
     void queryIsNormalizedByDefault() {
+        var fieldValue = "*" + randomAlphabetic(10);
         SolrQuery solrQuery =
                 new SolrQueryBuilder<>()
-                        .addQueryFieldByTerm(FIELD1, "*value1")
+                        .addQueryFieldByTerm(FIELD1, fieldValue)
                         .build();
 
-        assertThat(solrQuery.getQuery()).isEqualTo(FIELD1.name() + ":(\"\\*value1\")");
+        assertThat(solrQuery.getQuery()).isEqualTo(FIELD1.name() + ":(\"\\" + fieldValue + "\")");
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/trader/ExperimentTraderDaoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/trader/ExperimentTraderDaoIT.java
@@ -12,7 +12,6 @@ import org.springframework.test.jdbc.JdbcTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 import uk.ac.ebi.atlas.configuration.TestConfig;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
-import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
 
 import javax.inject.Inject;
 
@@ -28,9 +27,6 @@ class ExperimentTraderDaoIT {
     private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     @Inject
-    private SolrCloudCollectionProxyFactory solrCloudCollectionProxyFactory;
-
-    @Inject
     private JdbcTemplate jdbcTemplate;
 
     @Inject
@@ -38,7 +34,7 @@ class ExperimentTraderDaoIT {
 
     @BeforeEach
     void setUp() {
-        subject = new ExperimentTraderDao(namedParameterJdbcTemplate, solrCloudCollectionProxyFactory);
+        subject = new ExperimentTraderDao(namedParameterJdbcTemplate);
     }
 
     @Sql("/fixtures/gxa-experiment-fixture.sql")
@@ -57,8 +53,6 @@ class ExperimentTraderDaoIT {
                 .size().isEqualTo(JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "experiment", "private=FALSE"));
         assertThat(subject.fetchPublicExperimentAccessions(PROTEOMICS_BASELINE))
                 .isEmpty();
-        assertThat(subject.fetchPublicExperimentAccessions("foo", "bar"))
-                .isEmpty();
     }
 
     @Sql({"/fixtures/gxa-experiment-fixture.sql", "/fixtures/scxa-experiment-fixture.sql"})
@@ -70,24 +64,5 @@ class ExperimentTraderDaoIT {
                             .isNotEmpty()
                             .size().isLessThan(
                                     JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "experiment", "private=FALSE")));
-    }
-
-    @Sql({"/fixtures/gxa-experiment-fixture.sql", "/fixtures/scxa-experiment-fixture.sql"})
-    @Test
-    void notEmptyForCorrectCharacteristicType() {
-        assertThat(subject.fetchPublicExperimentAccessions("sex", "female"))
-                .isNotEmpty()
-                .containsExactlyInAnyOrder("E-EHCA-2", "E-MTAB-5061", "E-GEOD-81547");
-    }
-
-    @Sql({"/fixtures/gxa-experiment-fixture.sql", "/fixtures/scxa-experiment-fixture.sql"})
-    @Test
-    void returnAllExperimentsForInvalidCharacteristicNameOrType() {
-        assertThat(subject.fetchPublicExperimentAccessions("", "female"))
-                .isEmpty();
-        assertThat(subject.fetchPublicExperimentAccessions("sex", ""))
-                .isEmpty();
-        assertThat(subject.fetchPublicExperimentAccessions("", ""))
-                .isNotEmpty();
     }
 }


### PR DESCRIPTION
From an object-oriented design perspective, it was not appropriate to have a method with was serving only for single-cell experiments so moved related methods to the single-cell repo.

Related PR: https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/80