### PR TITLE
Add new solr schema fields for hca experiments endpoint

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/SingleCellAnalyticsCollectionProxy.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/SingleCellAnalyticsCollectionProxy.java
@@ -24,6 +24,10 @@ public class SingleCellAnalyticsCollectionProxy extends CollectionProxy<SingleCe
             new SingleCellAnalyticsSchemaField("characteristic_name");
     public static final SingleCellAnalyticsSchemaField CHARACTERISTIC_VALUE =
             new SingleCellAnalyticsSchemaField("characteristic_value");
+    public static final SingleCellAnalyticsSchemaField FACET_CHARACTERISTIC_VALUE =
+            new SingleCellAnalyticsSchemaField("facet_characteristic_value");
+    public static final SingleCellAnalyticsSchemaField ONTOLOGY_ANNOTATION =
+            new SingleCellAnalyticsSchemaField("ontology_annotation");
 
     public SingleCellAnalyticsCollectionProxy(SolrClient solrClient) {
         // scxa-analytics is an alias that points at scxa-analytics-vX


### PR DESCRIPTION
Added two new schema fields which are being used in solr query for HCA experiments. Please look at the corresponding [PR](https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/81) for details.