### PR TITLE
Feature #171667215 – Have independent (i.e. bulk and single cell) species and release metadata JSON files

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/configuration/BasePathsConfig.java
+++ b/src/main/java/uk/ac/ebi/atlas/configuration/BasePathsConfig.java
@@ -62,11 +62,11 @@ public class BasePathsConfig {
 
     @Bean
     public Path speciesPropertiesFilePath() {
-        return Paths.get(dataFilesLocation).resolve("species").resolve("species-properties.json");
+        return experimentsDirPath().resolve("species-properties.json");
     }
 
     @Bean
     public Path atlasInformationFilePath() {
-        return Paths.get(dataFilesLocation).resolve("species").resolve("release-metadata.json");
+        return experimentsDirPath().resolve("release-metadata.json");
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/species/admin/SpeciesAdminController.java
+++ b/src/main/java/uk/ac/ebi/atlas/species/admin/SpeciesAdminController.java
@@ -31,7 +31,7 @@ public class SpeciesAdminController extends JsonExceptionHandlingController {
             "List all available references species with their properties\n" +
             "\n" +
             "#### REFRESH\n" +
-            "Reload species properties from $ATLAS_DATA/species/species-properties.json";
+            "Reload species properties from $EXPERIMENTS_DATA/species-properties.json";
             // If the source of species properties changes, change the above. I don’t think it’s worth to expose the
             // paths in AtlasResource and add one more collaborator here for just this.
 

--- a/src/test/resources/configuration.properties
+++ b/src/test/resources/configuration.properties
@@ -1,2 +1,2 @@
 data.files.location = ${dataFilesLocation}
-experiment.files.location = ${dataFilesLocation}
+experiment.files.location = ${dataFilesLocation}/gxa


### PR DESCRIPTION
Look inside `gxa` or `scxa` for the JSON files instead of the common species directory.