### PR TITLE
Bugfix #171702527 – Web VM host names are leaked to public-facing links

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/home/species/SpeciesSummaryService.java
+++ b/src/main/java/uk/ac/ebi/atlas/home/species/SpeciesSummaryService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import org.apache.commons.lang3.tuple.Triple;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.species.Species;
 
@@ -29,6 +30,7 @@ public class SpeciesSummaryService {
         this.speciesSummaryDao = speciesSummaryDao;
     }
 
+    @Cacheable("speciesSummary")
     public ImmutableSortedMap<String, ImmutableList<SpeciesSummary>> getReferenceSpeciesSummariesGroupedByKingdom() {
         var kingdom2SpeciesSummary =
                 speciesSummaryDao.getExperimentCountBySpeciesAndExperimentType().stream()


### PR DESCRIPTION
Use the cache `speciesSummary` to store domain objects instead of using it for the JSON response.

See also:
* https://github.com/ebi-gene-expression-group/atlas-web-bulk/pull/61
* https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/90
