### PR TITLE
If expression equals “inf” return null & add test

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/baseline/BaselineExpression.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/baseline/BaselineExpression.java
@@ -37,7 +37,7 @@ public class BaselineExpression implements Expression {
     // NT is deprecated, shouldn't be present. "-" was documented as a "zero code. "NA" used in diff experiments.
     @Nullable
     public static BaselineExpression create(@Nullable String expressionLevelString) {
-        if (expressionLevelString == null) {
+        if (expressionLevelString == null || expressionLevelString.equals("inf")) {
             return null;
         }
 

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/baseline/BaselineExpressionTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/baseline/BaselineExpressionTest.java
@@ -37,6 +37,11 @@ public class BaselineExpressionTest {
                 .isNull();
     }
 
+    public void infStringRutrnsNull() {
+        assertThat(BaselineExpression.create("inf"))
+                .isNull();
+    }
+
     @Test
     public void jsonSerializationWithoutQuartiles() {
         JsonObject jsonObject = new BaselineExpression(1.0).toJson();


### PR DESCRIPTION
Fix a bug reported [here](https://github.com/ebi-gene-expression-group/atlas-web-bulk/issues/57).

The error in log is ```ERROR uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController [JsonExceptionHandlingController.java:36] - For input string: "inf" - java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2054)
	java.base/jdk.internal.math.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
	java.base/java.lang.Double.parseDouble(Double.java:543)```