### PR TITLE
Bugfix #172199054 – Multiexperiment heatmap levels beyond a value are filled with 0

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/solr/analytics/baseline/BaselineAnalyticsSearchDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/analytics/baseline/BaselineAnalyticsSearchDao.java
@@ -40,11 +40,11 @@ public class BaselineAnalyticsSearchDao {
                                                                    String species) {
         String response =
                 analyticsQueryClient.queryBuilder()
-                .baselineFacets()
-                .queryIdentifierSearch(geneQuery)
-                .queryConditionsSearch(conditionQuery)
-                .ofSpecies(species)
-                .fetch();
+                    .baselineFacets()
+                    .queryIdentifierSearch(geneQuery)
+                    .queryConditionsSearch(conditionQuery)
+                    .ofSpecies(species)
+                    .fetch();
 
         Configuration jsonPathConfiguration =
                 Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS);
@@ -53,9 +53,9 @@ public class BaselineAnalyticsSearchDao {
     }
 
     public List<Map<String, Object>> fetchExpressionLevelsPayload(SemanticQuery geneQuery,
-                                                           SemanticQuery conditionQuery,
-                                                           String species,
-                                                           String defaultQueryFactorType) {
+                                                                  SemanticQuery conditionQuery,
+                                                                  String species,
+                                                                  String defaultQueryFactorType) {
         String response = analyticsQueryClient.queryBuilder()
                 .baselineFacets()
                 .queryIdentifierSearch(geneQuery)

--- a/src/main/java/uk/ac/ebi/atlas/solr/analytics/query/AnalyticsQueryClient.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/analytics/query/AnalyticsQueryClient.java
@@ -35,7 +35,6 @@ import static uk.ac.ebi.atlas.solr.cloud.collections.BulkAnalyticsCollectionProx
 @Named
 @Scope("prototype")
 public class AnalyticsQueryClient {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(AnalyticsQueryClient.class);
     private final RestTemplate restTemplate;
     private final String solrBaseUrl;

--- a/src/main/resources/solr-queries/baseline.heatmap.pivot.query.json
+++ b/src/main/resources/solr-queries/baseline.heatmap.pivot.query.json
@@ -20,7 +20,7 @@
                   "assayGroupId": {
                     "type" : "terms",
                     "field": "assay_group_id",
-                    "limit": 1000,
+                    "limit": 5000,
                     "facet": {
                       "sumExpressionLevel": "sum(expression_level)"
                     }

--- a/src/main/resources/solr-queries/baseline.heatmap.pivot.query.json
+++ b/src/main/resources/solr-queries/baseline.heatmap.pivot.query.json
@@ -6,7 +6,7 @@
       "species": {
         "type" : "terms",
         "field": "species",
-        "limit": 1000,
+        "limit": -1,
         "facet": {
           "defaultQueryFactorType": {
             "type" : "terms",
@@ -15,12 +15,12 @@
               "experimentAccession": {
                 "type" : "terms",
                 "field": "experiment_accession",
-                "limit": 5000,
+                "limit": -1,
                 "facet": {
                   "assayGroupId": {
                     "type" : "terms",
                     "field": "assay_group_id",
-                    "limit": 5000,
+                    "limit": -1,
                     "facet": {
                       "sumExpressionLevel": "sum(expression_level)"
                     }

--- a/src/test/java/uk/ac/ebi/atlas/solr/analytics/query/AnalyticsQueryClientIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/analytics/query/AnalyticsQueryClientIT.java
@@ -190,6 +190,29 @@ class AnalyticsQueryClientIT {
                 .allMatch(type -> ExperimentType.get(type).isBaseline());
     }
 
+    @Test
+    void returnsAllResultsFound() {
+        var queryResponse =
+                goodSubject.queryBuilder()
+                        .baselineFacets()
+                        .queryIdentifierSearch(SemanticQuery.create(SemanticQueryTerm.create("MUC1", "symbol")))
+                        .ofSpecies("homo sapiens")
+                        .fetch();
+
+        var numberOfResults =
+                JsonPath.using(Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS))
+                        .parse(queryResponse)
+                        .<Integer>read("response.numFound");
+        var results =
+                JsonPath.using(Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS))
+                        .parse(queryResponse)
+                        .<List<?>>read("$..assayGroupId.buckets[*]");
+
+        assertThat(results)
+                .isNotEmpty()
+                .hasSize(numberOfResults);
+    }
+
     class TestableAnalyticsQueryClient extends AnalyticsQueryClient {
         TestableAnalyticsQueryClient(RestTemplate restTemplate,
                                      String solrBaseUrl,


### PR DESCRIPTION
We were setting hard limits for our baseline multiexperiment queries in Solr. The result was that the missing values were filled with 0s.

This fix addresses that issue and we’re now returning everything, instead of having large enough limits, setting them to -1 ensures that everything is in the Solr response.