### PR TITLE
Bugfix #172654192 – Values of metadata t-SNE plot are truncated

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/CollectionProxy.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/CollectionProxy.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 // https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
 // Some frameworks provide solutions for this: http://manifold.systems/docs.html#the-self-type
 // We leave it to the judicious Atlas developers to extend this class as intended.
-public abstract class CollectionProxy<SELF extends CollectionProxy> {
+public abstract class CollectionProxy<SELF extends CollectionProxy<?>> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CollectionProxy.class);
 
     public final SolrClient solrClient;

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/SingleCellAnalyticsCollectionProxy.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/SingleCellAnalyticsCollectionProxy.java
@@ -20,6 +20,8 @@ public class SingleCellAnalyticsCollectionProxy extends CollectionProxy<SingleCe
             new SingleCellAnalyticsSchemaField("factor_name");
     public static final SingleCellAnalyticsSchemaField FACTOR_VALUE =
             new SingleCellAnalyticsSchemaField("factor_value");
+    public static final SingleCellAnalyticsSchemaField FACET_FACTOR_VALUE =
+            new SingleCellAnalyticsSchemaField("facet_factor_value");
     public static final SingleCellAnalyticsSchemaField CHARACTERISTIC_NAME =
             new SingleCellAnalyticsSchemaField("characteristic_name");
     public static final SingleCellAnalyticsSchemaField CHARACTERISTIC_VALUE =

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrJsonFacetBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrJsonFacetBuilder.java
@@ -22,7 +22,7 @@ enum SolrFacetType {
     }
 }
 
-public class SolrJsonFacetBuilder<T extends CollectionProxy> {
+public class SolrJsonFacetBuilder<T extends CollectionProxy<?>> {
     private static final int DEFAULT_LIMIT = -1;
 
     private static final String DOMAIN_FILTER_TEMPLATE = "%s:%s";

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrJsonFacetBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrJsonFacetBuilder.java
@@ -1,12 +1,12 @@
 package uk.ac.ebi.atlas.solr.cloud.search;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import uk.ac.ebi.atlas.solr.cloud.CollectionProxy;
 import uk.ac.ebi.atlas.solr.cloud.SchemaField;
-
-import java.util.Collection;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
@@ -24,29 +24,19 @@ enum SolrFacetType {
 
 public class SolrJsonFacetBuilder<T extends CollectionProxy<?>> {
     private static final int DEFAULT_LIMIT = -1;
-
     private static final String DOMAIN_FILTER_TEMPLATE = "%s:%s";
 
-    private String facetField;
     // Support "terms" facets by default
     private String facetType = SolrFacetType.TERMS.name;
-    private String facetName;
+    private String facetField;
 
-    // Indicates if the builder is being used to build a nested sub-facet
-    private boolean nestedFacet = false;
-
-    private ImmutableSet.Builder<String> domainFiltersBuilder = ImmutableSet.builder();
-
-    private ImmutableSet.Builder<SolrJsonFacetBuilder> subfacetsBuilder = ImmutableSet.builder();
+    private final ImmutableSet.Builder<String> domainFiltersBuilder = ImmutableSet.builder();
+    private final ImmutableMap.Builder<String, SolrJsonFacetBuilder<?>> nestedFacetsBuilder = ImmutableMap.builder();
 
     private int limit = DEFAULT_LIMIT;
 
     public final <U extends SchemaField<T>> SolrJsonFacetBuilder<T> setFacetField(U field) {
         facetField = field.name();
-        // If the facet name hasn't been set yet, set it to the name of the field
-        if (StringUtils.isBlank(facetName)) {
-            facetName = field.name();
-        }
         return this;
     }
 
@@ -55,24 +45,13 @@ public class SolrJsonFacetBuilder<T extends CollectionProxy<?>> {
         return this;
     }
 
-    public final SolrJsonFacetBuilder<T> setFacetName(String name) {
-        facetName = name;
-        return this;
-    }
-
-    public final SolrJsonFacetBuilder<T> setNestedFacet(boolean nestedFacet) {
-        this.nestedFacet = nestedFacet;
+    public final SolrJsonFacetBuilder<T> addNestedFacet(String name, SolrJsonFacetBuilder<T> solrJsonFacetBuilder) {
+        nestedFacetsBuilder.put(name, solrJsonFacetBuilder);
         return this;
     }
 
     public final SolrJsonFacetBuilder<T> setLimit(int limit) {
         this.limit = limit;
-        return this;
-    }
-
-    // All sub-facets MUST have nestedFacet set to true
-    public final SolrJsonFacetBuilder<T> addSubFacets(Collection<SolrJsonFacetBuilder<T>> subFacets) {
-        subfacetsBuilder.addAll(subFacets);
         return this;
     }
 
@@ -90,39 +69,26 @@ public class SolrJsonFacetBuilder<T extends CollectionProxy<?>> {
             throw new IllegalArgumentException("A facet field must be set.");
         }
 
-        ImmutableSet<String> domainFilters = domainFiltersBuilder.build();
-        ImmutableSet<SolrJsonFacetBuilder> subFacets = subfacetsBuilder.build();
-
-        JsonObject facetWrapper = new JsonObject();
-
+        var facetWrapper = new JsonObject();
         facetWrapper.addProperty("type", facetType);
         facetWrapper.addProperty("field", facetField);
         facetWrapper.addProperty("limit", limit);
+        // https://lucene.apache.org/solr/guide/7_2/json-facet-api.html#TermsFacet
+        // > This makes stats for returned buckets exact.
+        facetWrapper.addProperty("refine", true);
 
-        if (!subFacets.isEmpty()) {
-            JsonObject subfacetWrapper = new JsonObject();
-
-            subFacets.forEach(facet ->
-                    subfacetWrapper.add(facet.facetName, facet.build()));
-
-            facetWrapper.add("facet", subfacetWrapper);
-        }
-
+        var domainFilters = domainFiltersBuilder.build();
         if (!domainFilters.isEmpty()) {
-            JsonObject filters = new JsonObject();
+            var filters = new JsonObject();
             filters.add("filter", GSON.toJsonTree(domainFilters));
-
             facetWrapper.add("domain", filters);
         }
 
-        if (nestedFacet) {
-            return facetWrapper;
-        }
-        else {
-            JsonObject result = new JsonObject();
-            result.add(facetName, facetWrapper);
+        facetWrapper.add(
+                "facet",
+                GSON.toJsonTree(
+                        Maps.transformValues(nestedFacetsBuilder.build(), SolrJsonFacetBuilder::build)));
 
-            return result;
-        }
+        return facetWrapper;
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
@@ -19,7 +19,7 @@ import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createOrBooleanQu
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createUpperBoundRangeQuery;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
-public class SolrQueryBuilder<T extends CollectionProxy> {
+public class SolrQueryBuilder<T extends CollectionProxy<?>> {
     // Some magic Solr number, from the logs:
     // ERROR (qtp511707818-76) [   ] o.a.s.s.HttpSolrCall null:java.lang.IllegalArgumentException:
     // maxSize must be <= 2147483630; got: 2147483646

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
@@ -1,8 +1,8 @@
 package uk.ac.ebi.atlas.solr.cloud.search;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrQuery.SortClause;
@@ -12,6 +12,7 @@ import uk.ac.ebi.atlas.solr.cloud.SchemaField;
 import java.util.Collection;
 import java.util.Map;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.stream.Collectors.joining;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createDoubleBoundRangeQuery;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createLowerBoundRangeQuery;
@@ -26,12 +27,11 @@ public class SolrQueryBuilder<T extends CollectionProxy<?>> {
     public static final int SOLR_MAX_ROWS = 2147483630;
     public static final int DEFAULT_ROWS = 100000;
 
-    private ImmutableSet.Builder<String> fqClausesBuilder = ImmutableSet.builder();
-    private ImmutableSet.Builder<String> qClausesBuilder = ImmutableSet.builder();
-    private ImmutableSet.Builder<String> flBuilder = ImmutableSet.builder();
-    private ImmutableList.Builder<SortClause> sortBuilder = ImmutableList.builder();
-
-    private SolrJsonFacetBuilder<T> facetBuilder;
+    private final ImmutableSet.Builder<String> fqClausesBuilder = ImmutableSet.builder();
+    private final ImmutableSet.Builder<String> qClausesBuilder = ImmutableSet.builder();
+    private final ImmutableSet.Builder<String> flBuilder = ImmutableSet.builder();
+    private final ImmutableList.Builder<SortClause> sortBuilder = ImmutableList.builder();
+    private final ImmutableMap.Builder<String, SolrJsonFacetBuilder<T>> facetsBuilder = ImmutableMap.builder();
 
     private int rows = DEFAULT_ROWS;
     private boolean normalize = true;
@@ -86,7 +86,7 @@ public class SolrQueryBuilder<T extends CollectionProxy<?>> {
     }
 
     public final <U extends SchemaField<T>> SolrQueryBuilder<T> setFieldList(Collection<U> fields) {
-        for (SchemaField field : fields) {
+        for (SchemaField<T> field : fields) {
             flBuilder.add(field.name());
         }
         return this;
@@ -106,8 +106,8 @@ public class SolrQueryBuilder<T extends CollectionProxy<?>> {
         return this;
     }
 
-    public SolrQueryBuilder<T> setFacets(SolrJsonFacetBuilder<T> facetBuilder) {
-        this.facetBuilder = facetBuilder;
+    public SolrQueryBuilder<T> addFacet(String facetName, SolrJsonFacetBuilder<T> solrJsonFacetBuilder) {
+        facetsBuilder.put(facetName, solrJsonFacetBuilder);
         return this;
     }
 
@@ -122,10 +122,11 @@ public class SolrQueryBuilder<T extends CollectionProxy<?>> {
         ImmutableSet<String> fl = flBuilder.build();
         ImmutableList<SortClause> sorts = sortBuilder.build();
 
-        JsonObject facets = new JsonObject();
-        if (facetBuilder != null) {
-            facets = facetBuilder.build();
-        }
+        var facets =
+                facetsBuilder.build().entrySet().stream()
+                        .collect(toImmutableMap(
+                                Map.Entry::getKey,
+                                entry -> entry.getValue().build()));
 
         return new SolrQuery()
                 .addFilterQuery(fqClauses.toArray(new String[0]))

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/SelectStreamBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/SelectStreamBuilder.java
@@ -4,22 +4,23 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.solr.client.solrj.io.stream.SelectStream;
 import org.apache.solr.client.solrj.io.stream.TupleStream;
+import uk.ac.ebi.atlas.solr.cloud.CollectionProxy;
 import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.TupleStreamBuilder;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
 
-public class SelectStreamBuilder extends TupleStreamBuilder {
-    private final TupleStreamBuilder tupleStreamBuilder;
+public class SelectStreamBuilder<T extends CollectionProxy<?>> extends TupleStreamBuilder<T> {
+    private final TupleStreamBuilder<T> tupleStreamBuilder;
     private final ImmutableList.Builder<String> selectedFieldsBuilder = ImmutableList.builder();
     private final ImmutableMap.Builder<String, String> fieldMapsBuilder = ImmutableMap.builder();
 
-    public SelectStreamBuilder(TupleStreamBuilder tupleStreamBuilder) {
+    public SelectStreamBuilder(TupleStreamBuilder<T> tupleStreamBuilder) {
         this.tupleStreamBuilder = tupleStreamBuilder;
     }
 
-    public SelectStreamBuilder(TupleStreamBuilder tupleStreamBuilder, ImmutableList<String> selectedFieldsBuilder) {
+    public SelectStreamBuilder(TupleStreamBuilder<T> tupleStreamBuilder, ImmutableList<String> selectedFieldsBuilder) {
         this.tupleStreamBuilder = tupleStreamBuilder;
         this.selectedFieldsBuilder.addAll(selectedFieldsBuilder);
     }
@@ -29,7 +30,7 @@ public class SelectStreamBuilder extends TupleStreamBuilder {
     //     return this;
     // }
 
-    public SelectStreamBuilder addFieldMapping(Map<String, String> fieldNamesMap) {
+    public SelectStreamBuilder<T> addFieldMapping(Map<String, String> fieldNamesMap) {
         fieldMapsBuilder.putAll(fieldNamesMap);
         return this;
     }

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/UniqueStreamBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/decorator/UniqueStreamBuilder.java
@@ -3,16 +3,17 @@ package uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.decorator;
 import org.apache.solr.client.solrj.io.eq.FieldEqualitor;
 import org.apache.solr.client.solrj.io.stream.TupleStream;
 import org.apache.solr.client.solrj.io.stream.UniqueStream;
+import uk.ac.ebi.atlas.solr.cloud.CollectionProxy;
 import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.TupleStreamBuilder;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-public class UniqueStreamBuilder extends TupleStreamBuilder {
-    private final TupleStreamBuilder tupleStreamBuilder;
+public class UniqueStreamBuilder<T extends CollectionProxy<?>> extends TupleStreamBuilder<T> {
+    private final TupleStreamBuilder<T> tupleStreamBuilder;
     private final String overField;
 
-    public UniqueStreamBuilder(TupleStreamBuilder tupleStreamBuilder, String fieldName) {
+    public UniqueStreamBuilder(TupleStreamBuilder<T> tupleStreamBuilder, String fieldName) {
         this.tupleStreamBuilder = tupleStreamBuilder;
         this.overField = fieldName;
     }

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/source/FacetStreamBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/source/FacetStreamBuilder.java
@@ -20,13 +20,13 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collection;
 
-public class FacetStreamBuilder<T extends CollectionProxy> extends TupleStreamBuilder<T> {
+public class FacetStreamBuilder<T extends CollectionProxy<?>> extends TupleStreamBuilder<T> {
     private final T collectionProxy;
     private final Bucket[] buckets;
 
+    private final ImmutableSet.Builder<Metric> metricsBuilder = ImmutableSet.builder();
+    private final ImmutableSet.Builder<FieldComparator> sortsBuilder = ImmutableSet.builder();
     private SolrQuery solrQuery;
-    private ImmutableSet.Builder<Metric> metricsBuilder = ImmutableSet.builder();
-    private ImmutableSet.Builder<FieldComparator> sortsBuilder = ImmutableSet.builder();
 
     public FacetStreamBuilder(T collectionProxy, Collection<SchemaField<T>> bucketFields) {
         this.collectionProxy = collectionProxy;

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/source/SearchStreamBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/source/SearchStreamBuilder.java
@@ -11,7 +11,7 @@ import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.TupleStreamBuilder
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-public class SearchStreamBuilder<T extends CollectionProxy> extends TupleStreamBuilder<T> {
+public class SearchStreamBuilder<T extends CollectionProxy<?>> extends TupleStreamBuilder<T> {
     private final T collectionProxy;
     private final SolrQuery solrQuery;
 

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/source/SearchStreamBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/source/SearchStreamBuilder.java
@@ -20,6 +20,14 @@ public class SearchStreamBuilder<T extends CollectionProxy<?>> extends TupleStre
         solrQuery = solrQueryBuilder.build();
     }
 
+    // Uses the /export query handler, it will override the rows parameter in SolrQueryBuilder/SolrQuery
+    // https://lucene.apache.org/solr/guide/7_1/stream-source-reference.html#search-parameters
+    // IMPORTANT: multivalued fields *MUST* have docValues enabled
+    public SearchStreamBuilder<T> returnAllDocs() {
+        solrQuery.add("qt", "/export");
+        return this;
+    }
+
     @Override
     protected TupleStream getRawTupleStream() {
         try {

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilderTest.java
@@ -22,7 +22,7 @@ import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 // Correctness of query syntax tested in SolrQueryUtilsTest
 class SolrQueryBuilderTest {
-    private static final class DummySchemaField extends SchemaField<CollectionProxy> {
+    private static final class DummySchemaField extends SchemaField<CollectionProxy<?>> {
         private DummySchemaField(String fieldName) {
             super(fieldName);
         }
@@ -139,14 +139,14 @@ class SolrQueryBuilderTest {
 
     @Test
     void jsonFacetsAreBuilt() {
-        SolrJsonFacetBuilder<CollectionProxy> jsonFacetBuilder = new SolrJsonFacetBuilder<>()
+        var jsonFacetBuilder = new SolrJsonFacetBuilder<>()
                 .setFacetField(FIELD1);
 
-        SolrQuery solrQuery = new SolrQueryBuilder<>()
-                .setFacets(jsonFacetBuilder)
+        var solrQuery = new SolrQueryBuilder<>()
+                .addFacet(FIELD1.name(), jsonFacetBuilder)
                 .build();
 
-        Map<?, ?> result = GSON.fromJson(solrQuery.get("json.facet"), Map.class);
+        var result = GSON.<Map<?, ?>>fromJson(solrQuery.get("json.facet"), Map.class);
 
         assertThat(result).isNotEmpty();
     }

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/source/SearchStreamBuilderIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/source/SearchStreamBuilderIT.java
@@ -1,7 +1,6 @@
 package uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.source;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.solr.client.solrj.SolrQuery.ORDER;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,104 +10,148 @@ import uk.ac.ebi.atlas.configuration.TestConfig;
 import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
 import uk.ac.ebi.atlas.solr.cloud.TupleStreamer;
 import uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy;
+import uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy;
 import uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder;
 
 import javax.inject.Inject;
 
 import java.io.UncheckedIOException;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.solr.client.solrj.SolrQuery.ORDER.asc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER;
 import static uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy.PROPERTY_NAME;
 import static uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy.PROPERTY_VALUE;
 import static uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy.SPECIES;
+import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.EXPERIMENT_ACCESSION;
+import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.FACTOR_VALUE;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = TestConfig.class)
 class SearchStreamBuilderIT {
+    private static final int MAX_NUM_ROWS = 100;
+
     @Inject
     private SolrCloudCollectionProxyFactory collectionProxyFactory;
 
     private BioentitiesCollectionProxy bioentitiesCollectionProxy;
+    private SingleCellAnalyticsCollectionProxy singleCellAnalyticsCollectionProxy;
 
     @BeforeEach
     void setUp() {
         bioentitiesCollectionProxy = collectionProxyFactory.create(BioentitiesCollectionProxy.class);
+        singleCellAnalyticsCollectionProxy = collectionProxyFactory.create(SingleCellAnalyticsCollectionProxy.class);
     }
 
     @Test
     void testMinimalQuery() {
-        SolrQueryBuilder<BioentitiesCollectionProxy> solrQueryBuilder = new SolrQueryBuilder<>();
-        solrQueryBuilder
-                .setFieldList(ImmutableSet.of(BIOENTITY_IDENTIFIER, SPECIES, PROPERTY_NAME, PROPERTY_VALUE))
-                .sortBy(BIOENTITY_IDENTIFIER, ORDER.asc);
+        var solrQueryBuilder =
+                new SolrQueryBuilder<BioentitiesCollectionProxy>()
+                        .setFieldList(ImmutableSet.of(BIOENTITY_IDENTIFIER, SPECIES, PROPERTY_NAME, PROPERTY_VALUE))
+                        .sortBy(BIOENTITY_IDENTIFIER, asc);
 
-        try (TupleStreamer tupleStreamer =
+        try (var tupleStreamer =
                      TupleStreamer.of(
                              new SearchStreamBuilder<>(bioentitiesCollectionProxy, solrQueryBuilder).build())) {
-
             assertThat(tupleStreamer.get().collect(toList())).isNotEmpty();
         }
     }
 
     @Test
     void testQuery() {
-        SolrQueryBuilder<BioentitiesCollectionProxy> solrQueryBuilder = new SolrQueryBuilder<>();
-        solrQueryBuilder
-                .addQueryFieldByTerm(SPECIES, "Mus_musculus")
-                .setFieldList(ImmutableSet.of(BIOENTITY_IDENTIFIER, SPECIES, PROPERTY_NAME, PROPERTY_VALUE))
-                .sortBy(BIOENTITY_IDENTIFIER, ORDER.asc);
+        var solrQueryBuilder =
+                new SolrQueryBuilder<BioentitiesCollectionProxy>()
+                        .addQueryFieldByTerm(SPECIES, "Mus_musculus")
+                        .setFieldList(ImmutableSet.of(BIOENTITY_IDENTIFIER, SPECIES, PROPERTY_NAME, PROPERTY_VALUE))
+                        .sortBy(BIOENTITY_IDENTIFIER, asc);
 
-        try (TupleStreamer tupleStreamer =
+        try (var tupleStreamer =
                      TupleStreamer.of(
                              new SearchStreamBuilder<>(bioentitiesCollectionProxy, solrQueryBuilder).build())) {
-
             assertThat(tupleStreamer.get().collect(toList()))
                     .allSatisfy(
                             tuple -> assertThat(tuple.getString(BIOENTITY_IDENTIFIER.name())).startsWith("ENSMUSG"));
-
         }
     }
 
     @Test
     void noResults() {
-        SolrQueryBuilder<BioentitiesCollectionProxy> solrQueryBuilder = new SolrQueryBuilder<>();
-        solrQueryBuilder
-                .addQueryFieldByTerm(PROPERTY_VALUE, "Foobar")
-                .setFieldList(ImmutableSet.of(BIOENTITY_IDENTIFIER, SPECIES, PROPERTY_NAME, PROPERTY_VALUE))
-                .sortBy(BIOENTITY_IDENTIFIER, ORDER.asc);
+        var solrQueryBuilder =
+                new SolrQueryBuilder<BioentitiesCollectionProxy>()
+                        .addQueryFieldByTerm(PROPERTY_VALUE, "Foobar")
+                        .setFieldList(ImmutableSet.of(BIOENTITY_IDENTIFIER, SPECIES, PROPERTY_NAME, PROPERTY_VALUE))
+                        .sortBy(BIOENTITY_IDENTIFIER, asc);
 
-        try (TupleStreamer tupleStreamer =
+        try (var tupleStreamer =
                      TupleStreamer.of(
                              new SearchStreamBuilder<>(bioentitiesCollectionProxy, solrQueryBuilder).build())) {
-
             assertThat(tupleStreamer.get().collect(toList()))
                     .isEmpty();
-
         }
     }
 
     @Test
     void requiresSortFieldAndToBePresentInFieldList() {
-        SolrQueryBuilder<BioentitiesCollectionProxy> solrQueryBuilder = new SolrQueryBuilder<>();
+        var solrQueryBuilder = new SolrQueryBuilder<BioentitiesCollectionProxy>();
+
         assertThatExceptionOfType(UncheckedIOException.class)
                 .isThrownBy(() -> new SearchStreamBuilder<>(bioentitiesCollectionProxy, solrQueryBuilder).build());
 
-        solrQueryBuilder.sortBy(BIOENTITY_IDENTIFIER, ORDER.asc);
+        solrQueryBuilder.sortBy(BIOENTITY_IDENTIFIER, asc);
         assertThatExceptionOfType(UncheckedIOException.class)
                 .isThrownBy(() -> new SearchStreamBuilder<>(bioentitiesCollectionProxy, solrQueryBuilder).build());
 
         solrQueryBuilder.setFieldList(BIOENTITY_IDENTIFIER);
-        try (TupleStreamer tupleStreamer =
+        try (var tupleStreamer =
                      TupleStreamer.of(
                              new SearchStreamBuilder<>(bioentitiesCollectionProxy, solrQueryBuilder).build())) {
-
             assertThat(tupleStreamer.get().collect(toList()))
                     .isNotEmpty();
+        }
+    }
 
+    @Test
+    void canReturnAllRowsWihtoutSetting() {
+        var numRows = ThreadLocalRandom.current().nextInt(MAX_NUM_ROWS);
+        var solrQueryBuilder =
+                new SolrQueryBuilder<SingleCellAnalyticsCollectionProxy>()
+                        .addQueryFieldByTerm(EXPERIMENT_ACCESSION, "E-EHCA-2")
+                        .setFieldList(EXPERIMENT_ACCESSION)
+                        .setRows(numRows)
+                        .sortBy(EXPERIMENT_ACCESSION, asc);
+
+        var searchStreamBuilder = new SearchStreamBuilder<>(singleCellAnalyticsCollectionProxy, solrQueryBuilder);
+        try (var tupleStreamer = TupleStreamer.of(searchStreamBuilder.build())) {
+            assertThat(tupleStreamer.get().count()).isEqualTo(numRows);
         }
 
+        var allDocsSearchStreamBuilder =
+                new SearchStreamBuilder<>(singleCellAnalyticsCollectionProxy, solrQueryBuilder).returnAllDocs();
+        try (var tupleStreamer = TupleStreamer.of(allDocsSearchStreamBuilder.build())) {
+            assertThat(tupleStreamer.get().count()).isGreaterThan(numRows);
+        }
+    }
+
+    @Test
+    void throwsIfFieldListContainsMultivaluedFieldWithoutDocValuesWhenReturningAllFields() {
+        var numRows = ThreadLocalRandom.current().nextInt(MAX_NUM_ROWS);
+        var solrQueryBuilder =
+                new SolrQueryBuilder<SingleCellAnalyticsCollectionProxy>()
+                        .addQueryFieldByTerm(EXPERIMENT_ACCESSION, "E-EHCA-2")
+                        .setFieldList(ImmutableSet.of(EXPERIMENT_ACCESSION, FACTOR_VALUE))
+                        .setRows(numRows)
+                        .sortBy(EXPERIMENT_ACCESSION, asc);
+
+        var searchStreamBuilder = new SearchStreamBuilder<>(singleCellAnalyticsCollectionProxy, solrQueryBuilder);
+        // No exceptions down here...
+        TupleStreamer.of(searchStreamBuilder.build());
+
+        var allDocsSearchStreamBuilder =
+                new SearchStreamBuilder<>(singleCellAnalyticsCollectionProxy, solrQueryBuilder).returnAllDocs();
+        assertThatExceptionOfType(UncheckedIOException.class)
+                .isThrownBy(() -> TupleStreamer.of(allDocsSearchStreamBuilder.build()));
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/source/SearchStreamBuilderIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/streamingexpressions/source/SearchStreamBuilderIT.java
@@ -114,7 +114,7 @@ class SearchStreamBuilderIT {
     }
 
     @Test
-    void canReturnAllRowsWihtoutSetting() {
+    void returnAllRowsOverridesRowsParameterInSolrQuery() {
         var numRows = ThreadLocalRandom.current().nextInt(MAX_NUM_ROWS);
         var solrQueryBuilder =
                 new SolrQueryBuilder<SingleCellAnalyticsCollectionProxy>()


### PR DESCRIPTION
This is a companion PR of https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/99. It adds all the necessary logic mentioned over there.

You can find more info about the JSON facet API here: https://lucene.apache.org/solr/guide/7_2/json-facet-api.html.