### PR TITLE
New ExperimentCollectionRepositoryClass

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentCollectionsRepository.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentCollectionsRepository.java
@@ -1,0 +1,10 @@
+package uk.ac.ebi.atlas.experiments;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ExperimentCollectionsRepository {
+    List<String> getExperimentCollections(String experimentAccession);
+}

--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentJsonSerializer.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentJsonSerializer.java
@@ -1,8 +1,8 @@
 package uk.ac.ebi.atlas.experiments;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonObject;
+import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
@@ -11,39 +11,16 @@ import java.text.SimpleDateFormat;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
+@Component
 public class ExperimentJsonSerializer {
-    public ExperimentJsonSerializer() {
-        throw new UnsupportedOperationException();
+
+    private final ExperimentCollectionsRepository experimentCollectionsRepository;
+
+    public ExperimentJsonSerializer(ExperimentCollectionsRepository experimentCollectionsRepository) {
+        this.experimentCollectionsRepository = experimentCollectionsRepository;
     }
 
-    private final static String CHAN_ZUCKERBERG_BIOHUB = "Chan-Zuckerberg Biohub";
-    private final static String HUMAN_CELL_ATLAS = "Human Cell Atlas";
-    private final static String MALARIA_CELL_ATLAS = "Malaria Cell Atlas";
-
-    private final static ImmutableMap<String, ImmutableSet<String>> EXPERIMENT2PROJECT =
-        ImmutableMap.<String, ImmutableSet<String>>builder()
-                .put("E-ENAD-15", ImmutableSet.of(CHAN_ZUCKERBERG_BIOHUB))
-                .put("E-GEOD-81547", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-GEOD-93593", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-MTAB-5061", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-GEOD-106540", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-MTAB-6701", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-MTAB-66782", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-HCAD-1", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-HCAD-10", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-HCAD-11", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-HCAD-13", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-HCAD-4", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-HCAD-5", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-HCAD-6", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-HCAD-7", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-HCAD-8", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-HCAD-9", ImmutableSet.of(HUMAN_CELL_ATLAS))
-                .put("E-CURD-2", ImmutableSet.of(MALARIA_CELL_ATLAS))
-                .put("E-CURD-3", ImmutableSet.of(MALARIA_CELL_ATLAS))
-                .build();
-
-    public static JsonObject serialize(Experiment<?> experiment) {
+    public JsonObject serialize(Experiment<?> experiment) {
         switch (experiment.getType()) {
             case SINGLE_CELL_RNASEQ_MRNA_BASELINE:
             case RNASEQ_MRNA_BASELINE:
@@ -60,33 +37,37 @@ public class ExperimentJsonSerializer {
         }
     }
 
-    private static JsonObject _serializeBaseline(Experiment<?> experiment) {
+    private JsonObject _serializeBaseline(Experiment<?> experiment) {
         var jsonObject = new JsonObject();
 
         jsonObject.addProperty("experimentAccession", experiment.getAccession());
         jsonObject.addProperty("experimentDescription", experiment.getDescription());
         jsonObject.addProperty("species", experiment.getSpecies().getName());
         jsonObject.addProperty("kingdom", experiment.getSpecies().getKingdom());
-        jsonObject.addProperty("loadDate", new SimpleDateFormat("dd-MM-yyyy").format(experiment.getLoadDate()));
-        jsonObject.addProperty("lastUpdate", new SimpleDateFormat("dd-MM-yyyy").format(experiment.getLastUpdate()));
-        jsonObject.addProperty("numberOfAssays", experiment.getAnalysedAssays().size());
-
-        jsonObject.addProperty("rawExperimentType", experiment.getType().toString());
-        jsonObject.addProperty("experimentType", experiment.getType().isBaseline() ? "Baseline" : "Differential");
+        jsonObject.addProperty(
+                "loadDate", new SimpleDateFormat("dd-MM-yyyy")
+                        .format(experiment.getLoadDate()));
+        jsonObject.addProperty(
+                "lastUpdate", new SimpleDateFormat("dd-MM-yyyy")
+                        .format(experiment.getLastUpdate()));
+        jsonObject.addProperty(
+                "numberOfAssays", experiment.getAnalysedAssays().size());
+        jsonObject.addProperty(
+                "rawExperimentType", experiment.getType().toString());
+        jsonObject.addProperty(
+                "experimentType", experiment.getType().isBaseline() ? "Baseline" : "Differential");
         jsonObject.add("technologyType", GSON.toJsonTree(experiment.getTechnologyType()));
-
         jsonObject.add(
                 "experimentalFactors",
                 GSON.toJsonTree(experiment.getExperimentDesign().getFactorHeaders()));
-
         jsonObject.add(
                 "experimentProjects",
-                GSON.toJsonTree(EXPERIMENT2PROJECT.getOrDefault(experiment.getAccession(), ImmutableSet.of())));
-
+                GSON.toJsonTree(
+                        experimentCollectionsRepository.getExperimentCollections(experiment.getAccession())));
         return jsonObject;
     }
 
-    private static JsonObject _serializeDifferential(DifferentialExperiment experiment) {
+    private JsonObject _serializeDifferential(DifferentialExperiment experiment) {
         var jsonObject = _serializeBaseline(experiment);
 
         jsonObject.addProperty("numberOfContrasts", experiment.getDataColumnDescriptors().size());
@@ -94,7 +75,7 @@ public class ExperimentJsonSerializer {
         return jsonObject;
     }
 
-    private static JsonObject _serializeMicroarray(MicroarrayExperiment experiment) {
+    private JsonObject _serializeMicroarray(MicroarrayExperiment experiment) {
         var jsonObject = _serializeDifferential(experiment);
 
         jsonObject.add(

--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentJsonService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentJsonService.java
@@ -31,13 +31,16 @@ public class ExperimentJsonService {
             MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL);
 
     private final ExperimentTrader experimentTrader;
+    private final ExperimentJsonSerializer experimentJsonSerializer;
 
-    public ExperimentJsonService(ExperimentTrader experimentTrader) {
+    public ExperimentJsonService(ExperimentTrader experimentTrader,
+                                 ExperimentJsonSerializer experimentJsonSerializer) {
         this.experimentTrader = experimentTrader;
+        this.experimentJsonSerializer = experimentJsonSerializer;
     }
 
     public JsonObject getExperimentJson(String experimentAccession, String accessKey) {
-        return ExperimentJsonSerializer.serialize(experimentTrader.getExperiment(experimentAccession, accessKey));
+        return experimentJsonSerializer.serialize(experimentTrader.getExperiment(experimentAccession, accessKey));
     }
 
     public ImmutableSet<JsonObject> getPublicExperimentsJson() {
@@ -47,7 +50,7 @@ public class ExperimentJsonService {
                         .<Experiment>comparingInt(experiment ->
                                 EXPERIMENT_TYPE_PRECEDENCE_LIST.indexOf(experiment.getType()))
                         .thenComparing(Experiment::getDisplayName))
-                .map(ExperimentJsonSerializer::serialize)
+                .map(experimentJsonSerializer::serialize)
                 .collect(toImmutableSet());
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
+++ b/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.web.client.RestTemplate;
+import uk.ac.ebi.atlas.experiments.ExperimentJsonSerializer;
 import uk.ac.ebi.atlas.trader.ExperimentRepository;
 
 @Configuration
@@ -24,4 +25,7 @@ public class TestConfig {
     public ExperimentRepository experimentRepository() {
         return experimentAccession -> null;
     }
+
+    @Bean
+    public ExperimentJsonSerializer experimentJsonSerializer() { return null; }
 }

--- a/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
+++ b/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
@@ -27,5 +27,7 @@ public class TestConfig {
     }
 
     @Bean
-    public ExperimentJsonSerializer experimentJsonSerializer() { return null; }
+    public ExperimentJsonSerializer experimentJsonSerializer() {
+        return new ExperimentJsonSerializer(experimentCollectionsRepository -> null);
+    }
 }

--- a/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonSerializerTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonSerializerTest.java
@@ -3,24 +3,39 @@ package uk.ac.ebi.atlas.experiments;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder.BaselineExperimentBuilder;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder.DifferentialExperimentBuilder;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder.MicroarrayExperimentBuilder;
 
 import java.text.SimpleDateFormat;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
 
+@ExtendWith(MockitoExtension.class)
 class ExperimentJsonSerializerTest {
     private static final Gson GSON = new Gson();
-    
-    @Test
-    void ExperimentJsonSerializerIsAUtilityClassAndCannotBeInstantiated() {
-        assertThatExceptionOfType(UnsupportedOperationException.class)
-                .isThrownBy(ExperimentJsonSerializer::new);
+    private static final String EXPERIMENT_ACCESSION = generateRandomExperimentAccession();
+
+    @Mock
+    private ExperimentCollectionsRepository experimentCollectionsRepositoryMock;
+
+    private ExperimentJsonSerializer subject;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        when(experimentCollectionsRepositoryMock.getExperimentCollections(EXPERIMENT_ACCESSION))
+                .thenReturn(List.of());
+
+        subject = new ExperimentJsonSerializer(experimentCollectionsRepositoryMock);
     }
 
     private void testBaseline(JsonObject result, Experiment<?> experiment) {
@@ -48,8 +63,10 @@ class ExperimentJsonSerializerTest {
 
     @Test
     void canSerializeBaselineExperiments() {
-        var experiment = new BaselineExperimentBuilder().build();
-        var result = ExperimentJsonSerializer.serialize(experiment);
+        var experiment = new BaselineExperimentBuilder()
+                .withExperimentAccession(EXPERIMENT_ACCESSION)
+                .build();
+        var result = subject.serialize(experiment);
         testBaseline(result, experiment);
 
         assertThat(result.get("experimentType").getAsString())
@@ -60,8 +77,10 @@ class ExperimentJsonSerializerTest {
 
     @Test
     void canSerializeDifferentialExperiments() {
-        var experiment = new DifferentialExperimentBuilder().build();
-        var result = ExperimentJsonSerializer.serialize(experiment);
+        var experiment = new DifferentialExperimentBuilder()
+                .withExperimentAccession(EXPERIMENT_ACCESSION)
+                .build();
+        var result = subject.serialize(experiment);
         testBaseline(result, experiment);
 
         assertThat(result.get("experimentType").getAsString())
@@ -74,8 +93,10 @@ class ExperimentJsonSerializerTest {
 
     @Test
     void canSerializeMicroarrayExperiments() {
-        var experiment = new MicroarrayExperimentBuilder().build();
-        var result = ExperimentJsonSerializer.serialize(experiment);
+        var experiment = new MicroarrayExperimentBuilder()
+                .withExperimentAccession(EXPERIMENT_ACCESSION)
+                .build();
+        var result = subject.serialize(experiment);
         testBaseline(result, experiment);
 
         assertThat(result.get("experimentType").getAsString())

--- a/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonSerializerTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonSerializerTest.java
@@ -17,13 +17,12 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
 
 @ExtendWith(MockitoExtension.class)
 class ExperimentJsonSerializerTest {
     private static final Gson GSON = new Gson();
-    private static final String EXPERIMENT_ACCESSION = generateRandomExperimentAccession();
 
     @Mock
     private ExperimentCollectionsRepository experimentCollectionsRepositoryMock;
@@ -32,7 +31,7 @@ class ExperimentJsonSerializerTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        when(experimentCollectionsRepositoryMock.getExperimentCollections(EXPERIMENT_ACCESSION))
+        when(experimentCollectionsRepositoryMock.getExperimentCollections(anyString()))
                 .thenReturn(List.of());
 
         subject = new ExperimentJsonSerializer(experimentCollectionsRepositoryMock);
@@ -63,9 +62,7 @@ class ExperimentJsonSerializerTest {
 
     @Test
     void canSerializeBaselineExperiments() {
-        var experiment = new BaselineExperimentBuilder()
-                .withExperimentAccession(EXPERIMENT_ACCESSION)
-                .build();
+        var experiment = new BaselineExperimentBuilder().build();
         var result = subject.serialize(experiment);
         testBaseline(result, experiment);
 
@@ -77,9 +74,7 @@ class ExperimentJsonSerializerTest {
 
     @Test
     void canSerializeDifferentialExperiments() {
-        var experiment = new DifferentialExperimentBuilder()
-                .withExperimentAccession(EXPERIMENT_ACCESSION)
-                .build();
+        var experiment = new DifferentialExperimentBuilder().build();
         var result = subject.serialize(experiment);
         testBaseline(result, experiment);
 
@@ -93,9 +88,7 @@ class ExperimentJsonSerializerTest {
 
     @Test
     void canSerializeMicroarrayExperiments() {
-        var experiment = new MicroarrayExperimentBuilder()
-                .withExperimentAccession(EXPERIMENT_ACCESSION)
-                .build();
+        var experiment = new MicroarrayExperimentBuilder().build();
         var result = subject.serialize(experiment);
         testBaseline(result, experiment);
 

--- a/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonServiceTest.java
@@ -1,17 +1,23 @@
 package uk.ac.ebi.atlas.experiments;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.testutils.MockExperiment;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
+import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ExperimentJsonServiceTest {
@@ -20,14 +26,21 @@ public class ExperimentJsonServiceTest {
     @Mock
     private ExperimentTrader experimentTraderMock;
 
+    @Mock
+    private ExperimentJsonSerializer experimentJsonSerializerMock;
+
     private ExperimentJsonService subject;
 
     @Before
     public void setUp() throws Exception {
-        when(experimentTraderMock.getPublicExperiments())
-                .thenReturn(ImmutableSet.of(MockExperiment.createBaselineExperiment(EXPERIMENT_ACCESSION)));
+        var experiment = MockExperiment.createBaselineExperiment(EXPERIMENT_ACCESSION);
 
-        subject = new ExperimentJsonService(experimentTraderMock);
+        when(experimentTraderMock.getPublicExperiments())
+                .thenReturn(ImmutableSet.of(experiment));
+        when(experimentJsonSerializerMock.serialize(experiment))
+                .thenReturn(getMockSerializedExperiment(experiment));
+
+        subject = new ExperimentJsonService(experimentTraderMock, experimentJsonSerializerMock);
     }
 
     @Test
@@ -50,5 +63,34 @@ public class ExperimentJsonServiceTest {
         assertThat(result.get("kingdom").getAsString()).isNotEmpty();
 
         assertThat(result.has("experimentalFactors")).isTrue();
+    }
+
+    private JsonObject getMockSerializedExperiment(Experiment<?> experiment) {
+        var jsonObject = new JsonObject();
+
+        jsonObject.addProperty("experimentAccession", experiment.getAccession());
+        jsonObject.addProperty("experimentDescription", experiment.getDescription());
+        jsonObject.addProperty("species", experiment.getSpecies().getName());
+        jsonObject.addProperty("kingdom", experiment.getSpecies().getKingdom());
+        jsonObject.addProperty(
+                "loadDate", new SimpleDateFormat("dd-MM-yyyy")
+                        .format(experiment.getLoadDate()));
+        jsonObject.addProperty(
+                "lastUpdate", new SimpleDateFormat("dd-MM-yyyy")
+                        .format(experiment.getLastUpdate()));
+        jsonObject.addProperty(
+                "numberOfAssays", experiment.getAnalysedAssays().size());
+        jsonObject.addProperty(
+                "rawExperimentType", experiment.getType().toString());
+        jsonObject.addProperty(
+                "experimentType", experiment.getType().isBaseline() ? "Baseline" : "Differential");
+        jsonObject.add("technologyType", GSON.toJsonTree(experiment.getTechnologyType()));
+        jsonObject.add(
+                "experimentalFactors",
+                GSON.toJsonTree(experiment.getExperimentDesign().getFactorHeaders()));
+        jsonObject.add(
+                "experimentProjects",
+                GSON.toJsonTree(List.of()));
+        return jsonObject;
     }
 }


### PR DESCRIPTION
As we have moved experiment to project mapping to database table `collections` and `experiment2collection` so to implement this functionality I have to make `ExperimentJsonSerializer` a non-static class.

`ExperimentJsonSerializer` is being used at various locations in `bulk` and `single-cell` atlas code so had to make appropriate changes at those places as well.