### PR TITLE
Fix inferred cell type not making into Experiment Design File

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/CondensedSdrfParser.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/CondensedSdrfParser.java
@@ -65,7 +65,7 @@ public class CondensedSdrfParser {
 
         // Get sdrf headers if the file exists
         if (dataFileHub.getExperimentFiles(experimentAccession).sdrf.exists()) {
-            Map<String, LinkedHashSet<String>> orderedHeaders = sdrfParser.parseHeader(experimentAccession);
+            var orderedHeaders = sdrfParser.parseHeader(experimentAccession);
             experimentDesign.setOrderedSampleCharacteristicHeaders(orderedHeaders.get("characteristics"));
             experimentDesign.setOrderedFactorHeaders(orderedHeaders.get("factorvalue"));
         }

--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/CondensedSdrfParser.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/CondensedSdrfParser.java
@@ -17,6 +17,7 @@ import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.resource.DataFileHub;
 
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,7 +65,7 @@ public class CondensedSdrfParser {
 
         // Get sdrf headers if the file exists
         if (dataFileHub.getExperimentFiles(experimentAccession).sdrf.exists()) {
-            Map<String, Set<String>> orderedHeaders = sdrfParser.parseHeader(experimentAccession);
+            Map<String, LinkedHashSet<String>> orderedHeaders = sdrfParser.parseHeader(experimentAccession);
             experimentDesign.setOrderedSampleCharacteristicHeaders(orderedHeaders.get("characteristics"));
             experimentDesign.setOrderedFactorHeaders(orderedHeaders.get("factorvalue"));
         }

--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParser.java
@@ -49,10 +49,10 @@ public class SdrfParser {
      * Returns a map containing the header values for characteristics and factors, maintaining the same order in
      * which they appear in the sdrf file.
      */
-    public Map<String, Set<String>> parseHeader(String experimentAccession) {
+    public Map<String, LinkedHashSet<String>> parseHeader(String experimentAccession) {
         try (TsvStreamer sdrfStreamer = dataFileHub.getExperimentFiles(experimentAccession).sdrf.get()) {
             // Headers of interest are of the form HeaderType[HeaderValue]
-            Pattern pattern = Pattern.compile("(.*?)(\\[)(.*?)(].*)");
+            var pattern = Pattern.compile("(.*?)(\\[)(.*?)(].*)");
 
             return Arrays.stream(
                     sdrfStreamer

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesign.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesign.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.atlas.model.experiment;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.ImmutableSortedSet;
 import org.jetbrains.annotations.NotNull;
@@ -117,23 +118,15 @@ public class ExperimentDesign implements Serializable {
         return assayHeaders;
     }
 
-    public Set<String> getSampleCharacteristicHeaders() {
-        if (!CollectionUtils.isEmpty(orderedSampleCharacteristicHeaders)) {
-            orderedSampleCharacteristicHeaders.addAll(sampleCharacteristicHeaders);
-            return Collections.unmodifiableSet(orderedSampleCharacteristicHeaders);
-        } else {
-            return Collections.unmodifiableSet(sampleCharacteristicHeaders);
-        }
+    public ImmutableSet<String> getSampleCharacteristicHeaders() {
+        ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+        return builder.addAll(orderedSampleCharacteristicHeaders).addAll(sampleCharacteristicHeaders).build();
     }
 
     // Factor headers are not normalized (see Factor::normalize), unlike factor type !
-    public Set<String> getFactorHeaders() {
-        if (!CollectionUtils.isEmpty(orderedFactorHeaders)) {
-            orderedFactorHeaders.addAll(factorHeaders);
-            return Collections.unmodifiableSet(orderedFactorHeaders);
-        } else {
-            return Collections.unmodifiableSet(factorHeaders);
-        }
+    public ImmutableSet<String> getFactorHeaders() {
+        ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+        return builder.addAll(orderedFactorHeaders).addAll(factorHeaders).build();
     }
 
     @Nullable

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesign.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesign.java
@@ -85,7 +85,7 @@ public class ExperimentDesign implements Serializable {
                           String factorHeader,
                           String factorValue,
                           OntologyTerm... factorOntologyTerms) {
-        Factor factor = new Factor(factorHeader, factorValue, factorOntologyTerms);
+        var factor = new Factor(factorHeader, factorValue, factorOntologyTerms);
         if (!assayId2Factor.containsKey(runOrAssay)) {
             assayId2Factor.put(runOrAssay, new FactorSet());
         }
@@ -119,6 +119,7 @@ public class ExperimentDesign implements Serializable {
 
     public Set<String> getSampleCharacteristicHeaders() {
         if (!CollectionUtils.isEmpty(orderedSampleCharacteristicHeaders)) {
+            orderedSampleCharacteristicHeaders.addAll(sampleCharacteristicHeaders);
             return Collections.unmodifiableSet(orderedSampleCharacteristicHeaders);
         } else {
             return Collections.unmodifiableSet(sampleCharacteristicHeaders);
@@ -128,6 +129,7 @@ public class ExperimentDesign implements Serializable {
     // Factor headers are not normalized (see Factor::normalize), unlike factor type !
     public Set<String> getFactorHeaders() {
         if (!CollectionUtils.isEmpty(orderedFactorHeaders)) {
+            orderedFactorHeaders.addAll(factorHeaders);
             return Collections.unmodifiableSet(orderedFactorHeaders);
         } else {
             return Collections.unmodifiableSet(factorHeaders);
@@ -136,13 +138,13 @@ public class ExperimentDesign implements Serializable {
 
     @Nullable
     public SampleCharacteristic getSampleCharacteristic(String runOrAssay, String sampleHeader) {
-        SampleCharacteristics sampleCharacteristics = this.assayId2SampleCharacteristic.get(runOrAssay);
+        var sampleCharacteristics = this.assayId2SampleCharacteristic.get(runOrAssay);
         return (sampleCharacteristics == null) ? null :  sampleCharacteristics.get(sampleHeader);
     }
 
     @Nullable
     public Factor getFactor(String runOrAssay, String factorHeader) {
-        FactorSet factorSet = assayId2Factor.get(runOrAssay);
+        var factorSet = assayId2Factor.get(runOrAssay);
         if (factorSet == null) {
             return null;
         }
@@ -151,10 +153,10 @@ public class ExperimentDesign implements Serializable {
 
     @Nullable
     public String getFactorValue(String runOrAssay, String factorHeader) {
-        FactorSet factorSet = assayId2Factor.get(runOrAssay);
+        var factorSet = assayId2Factor.get(runOrAssay);
         if (factorSet != null) {
 
-            Factor factor = factorSet.factorOfType(Factor.normalize(factorHeader));
+            var factor = factorSet.factorOfType(Factor.normalize(factorHeader));
             return factor == null ? null : factor.getValue();
         }
         return null;
@@ -194,13 +196,13 @@ public class ExperimentDesign implements Serializable {
     }
 
     public Map<String, String> getFactorValues(String runOrAssay) {
-        FactorSet factorSet = assayId2Factor.get(runOrAssay);
+        var factorSet = assayId2Factor.get(runOrAssay);
 
         if (factorSet == null) {
             return ImmutableMap.of();
         }
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-        for (Factor factor : factorSet) {
+        for (var factor : factorSet) {
             builder.put(factor.getHeader(), factor.getValue());
         }
 
@@ -216,7 +218,7 @@ public class ExperimentDesign implements Serializable {
     }
 
     public Collection<SampleCharacteristic> getSampleCharacteristics(String runOrAssay) {
-        SampleCharacteristics sampleCharacteristics = this.assayId2SampleCharacteristic.get(runOrAssay);
+        var sampleCharacteristics = this.assayId2SampleCharacteristic.get(runOrAssay);
         return (sampleCharacteristics == null ? new SampleCharacteristics() : sampleCharacteristics).values();
     }
 
@@ -237,7 +239,7 @@ public class ExperimentDesign implements Serializable {
         for (String assayAccession: assayAccessions) {
             Map<String, String> assaySamples = getSampleCharacteristicsValues(assayAccession);
 
-            for (String sampleName : assaySamples.keySet()) {
+            for (var sampleName : assaySamples.keySet()) {
                 if ("organism".equalsIgnoreCase(sampleName)) {
                     return assaySamples.get(sampleName);
                 }

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesign.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesign.java
@@ -119,14 +119,15 @@ public class ExperimentDesign implements Serializable {
     }
 
     public ImmutableSet<String> getSampleCharacteristicHeaders() {
-        ImmutableSet.Builder<String> builder = ImmutableSet.builder();
-        return builder.addAll(orderedSampleCharacteristicHeaders).addAll(sampleCharacteristicHeaders).build();
+        return ImmutableSet.<String>builder()
+                .addAll(orderedSampleCharacteristicHeaders)
+                .addAll(sampleCharacteristicHeaders)
+                .build();
     }
 
     // Factor headers are not normalized (see Factor::normalize), unlike factor type !
     public ImmutableSet<String> getFactorHeaders() {
-        ImmutableSet.Builder<String> builder = ImmutableSet.builder();
-        return builder.addAll(orderedFactorHeaders).addAll(factorHeaders).build();
+        return ImmutableSet.<String>builder().addAll(orderedFactorHeaders).addAll(factorHeaders).build();
     }
 
     @Nullable

--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesign.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesign.java
@@ -47,8 +47,8 @@ public class ExperimentDesign implements Serializable {
     private Set<String> factorHeaders = new LinkedHashSet<>();
 
     // Headers retrieved from the SDRF file, which maintain a curated order
-    private Set<String> orderedSampleCharacteristicHeaders;
-    private Set<String> orderedFactorHeaders;
+    private Set<String> orderedSampleCharacteristicHeaders = new LinkedHashSet<>();
+    private Set<String> orderedFactorHeaders = new LinkedHashSet<>();
 
     // Assay ID -> sample characteristics
     private Map<String, SampleCharacteristics> assayId2SampleCharacteristic = new HashMap<>();
@@ -119,15 +119,21 @@ public class ExperimentDesign implements Serializable {
     }
 
     public ImmutableSet<String> getSampleCharacteristicHeaders() {
-        return ImmutableSet.<String>builder()
-                .addAll(orderedSampleCharacteristicHeaders)
-                .addAll(sampleCharacteristicHeaders)
-                .build();
+        if(!orderedSampleCharacteristicHeaders.isEmpty()) {
+            return ImmutableSet.<String>builder()
+                    .addAll(orderedSampleCharacteristicHeaders)
+                    .addAll(sampleCharacteristicHeaders)
+                    .build();
+        }
+        return ImmutableSet.<String>builder().addAll(sampleCharacteristicHeaders).build();
     }
 
     // Factor headers are not normalized (see Factor::normalize), unlike factor type !
     public ImmutableSet<String> getFactorHeaders() {
-        return ImmutableSet.<String>builder().addAll(orderedFactorHeaders).addAll(factorHeaders).build();
+        if(!orderedFactorHeaders.isEmpty()) {
+            return ImmutableSet.<String>builder().addAll(orderedFactorHeaders).addAll(factorHeaders).build();
+        }
+        return ImmutableSet.<String>builder().addAll(factorHeaders).build();
     }
 
     @Nullable

--- a/src/main/java/uk/ac/ebi/atlas/trader/ExperimentDesignParser.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ExperimentDesignParser.java
@@ -14,11 +14,9 @@ import uk.ac.ebi.atlas.resource.DataFileHub;
 
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Component
@@ -52,10 +50,10 @@ public class ExperimentDesignParser {
         try (TsvStreamer tsvStreamer = r.get()) {
             Iterator<String[]> lineIterator = tsvStreamer.get().iterator();
 
-            ExperimentDesign experimentDesign = new ExperimentDesign();
+            var experimentDesign = new ExperimentDesign();
 
             if (dataFileHub.getExperimentFiles(experimentAccession).sdrf.exists()) {
-                Map<String, Set<String>> headers = sdrfParser.parseHeader(experimentAccession);
+                Map<String, LinkedHashSet<String>> headers = sdrfParser.parseHeader(experimentAccession);
                 experimentDesign.setOrderedSampleCharacteristicHeaders(headers.get("characteristics"));
                 experimentDesign.setOrderedFactorHeaders(headers.get("factorvalue"));
             }
@@ -77,37 +75,37 @@ public class ExperimentDesignParser {
                         headerLine.length - (sampleHeaderIndexes.size() + sampleValueOntologyTermHeaderIndexes.size() +
                                 factorHeaderIndexes.size() + factorValueOntologyTermHeaderIndexes.size());
 
-                for (String assayHeaderField : Arrays.copyOf(headerLine, headersStartIndex)) {
+                for (var assayHeaderField : Arrays.copyOf(headerLine, headersStartIndex)) {
                     experimentDesign.addAssayHeader(assayHeaderField);
                 }
 
                 while (lineIterator.hasNext()) {
                     String[] line = lineIterator.next();
 
-                    String runOrAssay = line[0];
+                    var runOrAssay = line[0];
                     if (headersStartIndex > 1) {
                         experimentDesign.putArrayDesign(runOrAssay, line[1]);
                     }
 
-                    for (String sampleHeader : sampleHeaderIndexes.keySet()) {
-                        String sampleValue = line[sampleHeaderIndexes.get(sampleHeader)];
+                    for (var sampleHeader : sampleHeaderIndexes.keySet()) {
+                        var sampleValue = line[sampleHeaderIndexes.get(sampleHeader)];
 
-                        Integer sampleValueOntologyTermIndex =
+                        var sampleValueOntologyTermIndex =
                                 sampleValueOntologyTermHeaderIndexes.get(sampleHeader);
-                        OntologyTerm[] sampleValueOntologyTerms =
+                        var sampleValueOntologyTerms =
                                 createOntologyTerms(line, sampleValueOntologyTermIndex);
-                        SampleCharacteristic sampleCharacteristic =
+                        var sampleCharacteristic =
                                 SampleCharacteristic.create(sampleHeader, sampleValue, sampleValueOntologyTerms);
 
                         experimentDesign.putSampleCharacteristic(runOrAssay, sampleHeader, sampleCharacteristic);
                     }
 
-                    for (String factorHeader : factorHeaderIndexes.keySet()) {
-                        String factorValue = line[factorHeaderIndexes.get(factorHeader)];
+                    for (var factorHeader : factorHeaderIndexes.keySet()) {
+                        var factorValue = line[factorHeaderIndexes.get(factorHeader)];
 
-                        Integer factorValueOntologyTermIndex =
+                        var factorValueOntologyTermIndex =
                                 factorValueOntologyTermHeaderIndexes.get(factorHeader);
-                        OntologyTerm[] factorValueOntologyTerms =
+                        var factorValueOntologyTerms =
                                 createOntologyTerms(line, factorValueOntologyTermIndex);
 
                         experimentDesign.putFactor(runOrAssay, factorHeader, factorValue, factorValueOntologyTerms);
@@ -125,19 +123,19 @@ public class ExperimentDesignParser {
         }
 
         ImmutableList.Builder<OntologyTerm> ontologyTermBuilder = new ImmutableList.Builder<>();
-        String uriField = line[ontologyTermIndex];
-        for (String uri : uriField.split(ONTOLOGY_TERM_DELIMITER)) {
+        var uriField = line[ontologyTermIndex];
+        for (var uri : uriField.split(ONTOLOGY_TERM_DELIMITER)) {
             ontologyTermBuilder.add(OntologyTerm.createFromURI(uri));
         }
-        List<OntologyTerm> ontologyTermList = ontologyTermBuilder.build();
+        var ontologyTermList = ontologyTermBuilder.build();
 
         return ontologyTermList.toArray(new OntologyTerm[0]);
     }
 
     private Map<String, Integer> extractHeaderIndexes(String[] columnHeaders, Pattern columnHeaderPattern) {
         Map<String, Integer> map = new TreeMap<>();
-        for (int i = 0; i < columnHeaders.length; i++) {
-            String matchingHeaderContent = extractMatchingContent(columnHeaders[i], columnHeaderPattern);
+        for (var i = 0; i < columnHeaders.length; i++) {
+            var matchingHeaderContent = extractMatchingContent(columnHeaders[i], columnHeaderPattern);
             if (matchingHeaderContent != null) {
                 map.put(matchingHeaderContent, i);
             }
@@ -147,7 +145,7 @@ public class ExperimentDesignParser {
 
     @Nullable
     static String extractMatchingContent(String string, Pattern pattern) {
-        Matcher matcher = pattern.matcher(string);
+        var matcher = pattern.matcher(string);
         if (matcher.matches()) {
             return matcher.group(1);
         }

--- a/src/main/java/uk/ac/ebi/atlas/trader/ExperimentDesignParser.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ExperimentDesignParser.java
@@ -53,7 +53,7 @@ public class ExperimentDesignParser {
             var experimentDesign = new ExperimentDesign();
 
             if (dataFileHub.getExperimentFiles(experimentAccession).sdrf.exists()) {
-                Map<String, LinkedHashSet<String>> headers = sdrfParser.parseHeader(experimentAccession);
+                var headers = sdrfParser.parseHeader(experimentAccession);
                 experimentDesign.setOrderedSampleCharacteristicHeaders(headers.get("characteristics"));
                 experimentDesign.setOrderedFactorHeaders(headers.get("factorvalue"));
             }

--- a/src/test/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/CondensedSdrfParserTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentimport/condensedSdrf/CondensedSdrfParserTest.java
@@ -147,13 +147,9 @@ public class CondensedSdrfParserTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    @BeforeClass
-    public static void setUpClass() {
-        dataFileHub = MockDataFileHub.create();
-    }
-
     @Before
     public void setUp() {
+        dataFileHub = MockDataFileHub.create();
         subject = new CondensedSdrfParser(dataFileHub, mockSdrfParser);
     }
 

--- a/src/test/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParserTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParserTest.java
@@ -73,7 +73,7 @@ public class SdrfParserTest {
 
         dataFileHub.addSdrfFile(experimentAccession, Arrays.asList(SDRF_TXT_MIXED_SPACING));
 
-        Map<String, LinkedHashSet<String>> result = subject.parseHeader(experimentAccession);
+        var result = subject.parseHeader(experimentAccession);
 
         assertThat(result)
                 .hasSize(2)
@@ -92,7 +92,7 @@ public class SdrfParserTest {
 
         dataFileHub.addSdrfFile(experimentAccession, Arrays.asList(SDRF_TXT_NO_FACTORS));
 
-        Map<String, LinkedHashSet<String>> result = subject.parseHeader(experimentAccession);
+        var result = subject.parseHeader(experimentAccession);
 
         assertThat(result)
                 .hasSize(1)

--- a/src/test/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParserTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentimport/sdrf/SdrfParserTest.java
@@ -7,8 +7,8 @@ import uk.ac.ebi.atlas.testutils.MockDataFileHub;
 import uk.ac.ebi.atlas.testutils.RandomDataTestUtils;
 
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -73,7 +73,7 @@ public class SdrfParserTest {
 
         dataFileHub.addSdrfFile(experimentAccession, Arrays.asList(SDRF_TXT_MIXED_SPACING));
 
-        Map<String, Set<String>> result = subject.parseHeader(experimentAccession);
+        Map<String, LinkedHashSet<String>> result = subject.parseHeader(experimentAccession);
 
         assertThat(result)
                 .hasSize(2)
@@ -92,7 +92,7 @@ public class SdrfParserTest {
 
         dataFileHub.addSdrfFile(experimentAccession, Arrays.asList(SDRF_TXT_NO_FACTORS));
 
-        Map<String, Set<String>> result = subject.parseHeader(experimentAccession);
+        Map<String, LinkedHashSet<String>> result = subject.parseHeader(experimentAccession);
 
         assertThat(result)
                 .hasSize(1)

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTableTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTableTest.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.model.experiment;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +37,10 @@ class ExperimentDesignTableTest {
 
         when(experimentDesignMock.getAllRunOrAssay())
                 .thenReturn(ImmutableSortedSet.copyOf(experiment.getAnalysedAssays()));
+        when(experimentDesignMock.getSampleCharacteristicHeaders())
+                .thenReturn(ImmutableSet.of());
+        when(experimentDesignMock.getFactorHeaders())
+                .thenReturn(ImmutableSet.of());
 
         subject = new ExperimentDesignTable(experiment);
 
@@ -68,6 +73,10 @@ class ExperimentDesignTableTest {
 
         when(experimentDesignMock.getAllRunOrAssay())
                 .thenReturn(ImmutableSortedSet.copyOf(scExperiment.getAnalysedAssays()));
+        when(experimentDesignMock.getSampleCharacteristicHeaders())
+                .thenReturn(ImmutableSet.of());
+        when(experimentDesignMock.getFactorHeaders())
+                .thenReturn(ImmutableSet.of());
 
         subject = new ExperimentDesignTable(scExperiment);
 
@@ -88,6 +97,10 @@ class ExperimentDesignTableTest {
                         .collect(toImmutableSortedSet(naturalOrder()));
 
         when(experimentDesignMock.getAllRunOrAssay()).thenReturn(assays);
+        when(experimentDesignMock.getSampleCharacteristicHeaders())
+                .thenReturn(ImmutableSet.of());
+        when(experimentDesignMock.getFactorHeaders())
+                .thenReturn(ImmutableSet.of());
 
         subject = new ExperimentDesignTable(scExperiment);
         assertThat(subject.asJson().getAsJsonArray("data").size()).isLessThanOrEqualTo(JSON_TABLE_MAX_ROWS);

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTest.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.model.experiment;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.SetMultimap;
 import org.junit.Test;
@@ -32,6 +33,8 @@ public class ExperimentDesignTest {
     private static final OntologyTerm FACTOR_ONTOLOGY_TERM3 = OntologyTerm.create(FACTOR_ONTOLOGY_TERM_ID3);
 
     private static final String SAMPLE_HEADER = "SAMPLE_HEADER1";
+    private static final String SAMPLE_HEADER2 = "SAMPLE_HEADER2";
+    private static final String SAMPLE_HEADER3 = "SAMPLE_HEADER3";
 
     private static final String SAMPLE_VALUE1 = "SAMPLE_VALUE1";
     private static final String SAMPLE_VALUE2 = "SAMPLE_VALUE2";
@@ -110,5 +113,26 @@ public class ExperimentDesignTest {
         subject.putFactor(ASSAY2, FACTOR_HEADER2, FACTOR_VALUE2, FACTOR_ONTOLOGY_TERM2);
 
         assertEquals(subject.getFactorValue(ASSAY1, FACTOR_HEADER), FACTOR_VALUE);
+    }
+
+    @Test
+    public void returnAllOrderedAndSimpleFactorHeaders() {
+        subject = new ExperimentDesign();
+        subject.setOrderedFactorHeaders(ImmutableSet.of(FACTOR_HEADER2, FACTOR_HEADER3));
+        subject.putFactor(ASSAY1, FACTOR_HEADER, FACTOR_VALUE, FACTOR_ONTOLOGY_TERM1);
+
+        assertEquals(subject.getFactorHeaders().size(), 3);
+    }
+
+    @Test
+    public void returnAllOrderedAndSimpleSampleCharacteristicsHeaders() {
+        subject = new ExperimentDesign();
+        subject.setOrderedSampleCharacteristicHeaders(ImmutableSet.of(SAMPLE_HEADER2, SAMPLE_HEADER3));
+        subject.putSampleCharacteristic(
+                ASSAY1,
+                SAMPLE_HEADER,
+                SampleCharacteristic.create(SAMPLE_HEADER, SAMPLE_VALUE1, SAMPLE_ONTOLOGY_TERM1));
+
+        assertEquals(subject.getSampleCharacteristicHeaders().size(), 3);
     }
 }


### PR DESCRIPTION
The bug was in a way how we were getting `sampleCharacteristics` and `factors`. `ExperimentDesign` class has four sets that are:
-`orderedSampleCharacteristicHeaders`
-`sampleCharacteristicHeaders`
-`orderedFactorHeaders`
-`factorHeaders`

So when we were returning, we were just returning `orderedFactorHeaders` but the correct way was to return the union of `orderedFactorHeaders` and `factorHeaders`

To make this functionality change reflect in the web app we need to update the experiment design files for all experiments.