### PR TITLE
Add double quotes to species param

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
@@ -23,7 +23,7 @@ public class UrlHelpers {
                 .fromCurrentContextPath()
                 .path("/experiments")
                 .query("species={species}")
-                .buildAndExpand(species)
+                .buildAndExpand("\"" + species + "\"")
                 .toUriString();
     }
 

--- a/src/test/java/uk/ac/ebi/atlas/utils/UrlHelpersIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/utils/UrlHelpersIT.java
@@ -43,12 +43,12 @@ class UrlHelpersIT {
 
     @Test
     @DisplayName("Experiments table link filtered by species points at /experiments?species={species}")
-    void speciesUrl() throws Exception {
+    void speciesHaveDoubleQoutesInUrl() throws Exception {
         var species = generateRandomSpecies();
 
         assertThat(new URL(getExperimentsFilteredBySpeciesUrl(species.getReferenceName())))
                 .hasPath("/experiments")
-                .hasParameter("species", species.getReferenceName());
+                .hasParameter("species", "\"" + species.getReferenceName() + "\"");
     }
 
     @Test


### PR DESCRIPTION
Added double-quotes for species parameter to get experiments. For context, please refer to this [pivotal story](https://www.pivotaltracker.com/story/show/175303117)