### PR TITLE
Allow cell type marker gene file added to archive

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/resource/DataFileHub.java
+++ b/src/main/java/uk/ac/ebi/atlas/resource/DataFileHub.java
@@ -467,11 +467,11 @@ public class DataFileHub {
 //        }
         // Retrieves cell type marker gene files with - and _
         private Set<String> retrieveStringsFromFileNames(String experimentAccession, String filePathTemplate) {
-            Path markerGeneFilePathTemplate =
+            var markerGeneFilePathTemplate =
                     experimentsMageTabDirLocation.resolve(
                             MessageFormat.format(filePathTemplate, experimentAccession, "(\\S+)"));
 
-            Pattern markerGeneTsvFileRegex = Pattern.compile(markerGeneFilePathTemplate.getFileName().toString());
+            var markerGeneTsvFileRegex = Pattern.compile(markerGeneFilePathTemplate.getFileName().toString());
 
             ImmutableSet.Builder<String> stringValues = ImmutableSet.builder();
             try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(markerGeneFilePathTemplate.getParent())) {
@@ -491,11 +491,11 @@ public class DataFileHub {
 
         // Retrieves k or perplexity values from single cell file names
         private Set<Integer> retrieveIntegersFromFileNames(String experimentAccession, String filePathTemplate) {
-            Path tSnePlotFilePathTemplate =
+            var tSnePlotFilePathTemplate =
                     experimentsMageTabDirLocation.resolve(
                             MessageFormat.format(filePathTemplate, experimentAccession, "(\\d+)"));
 
-            Pattern tSnePlotTsvFileRegex = Pattern.compile(tSnePlotFilePathTemplate.getFileName().toString());
+            var tSnePlotTsvFileRegex = Pattern.compile(tSnePlotFilePathTemplate.getFileName().toString());
 
             ImmutableSet.Builder<Integer> integerValues = ImmutableSet.builder();
             try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(tSnePlotFilePathTemplate.getParent())) {

--- a/src/test/java/uk/ac/ebi/atlas/resource/DataFileHubIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/resource/DataFileHubIT.java
@@ -158,13 +158,14 @@ class DataFileHubIT {
 
         @Test
         void findsCellTypeMarkerGeneFiles(@Value("${data.files.location}") String dataFilesLocation) {
-            String experimentAccession = "E-MTAB-5061";
+            String experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
             DataFileHub subject = new DataFileHub(dataFilesPath.resolve("scxa"));
             LOGGER.info("Test cell type marker gene files for experiment {}", experimentAccession);
             assertThat(subject.getSingleCellExperimentFiles(experimentAccession).markerGeneTsvs.values()
                     .stream().map(path -> path.getPath()))
                     .contains(Path.of(dataFilesLocation +
-                            "/scxa/magetab/E-MTAB-5061/E-MTAB-5061.marker_genes_inferred_cell_type_-_ontology_labels.tsv"));
+                            "/scxa/magetab/" + experimentAccession + "/" + experimentAccession +
+                            ".marker_genes_inferred_cell_type_-_ontology_labels.tsv"));
         }
 
         @Test

--- a/src/test/java/uk/ac/ebi/atlas/resource/DataFileHubIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/resource/DataFileHubIT.java
@@ -142,7 +142,7 @@ class DataFileHubIT {
 
         @Test
         void findsTSnePlotFiles() {
-            String experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+            var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
             subject = new DataFileHub(dataFilesPath.resolve("scxa"));
             LOGGER.info("Test tsne plot files for experiment {}", experimentAccession);
             assertAtlasResourceExists(subject.getSingleCellExperimentFiles(experimentAccession).tSnePlotTsvs.values());
@@ -150,16 +150,16 @@ class DataFileHubIT {
 
         @Test
         void findsMarkerGeneFiles() {
-            String experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
-            DataFileHub subject = new DataFileHub(dataFilesPath.resolve("scxa"));
+            var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+            var subject = new DataFileHub(dataFilesPath.resolve("scxa"));
             LOGGER.info("Test marker gene files for experiment {}", experimentAccession);
             assertAtlasResourceExists(subject.getSingleCellExperimentFiles(experimentAccession).markerGeneTsvs.values());
         }
 
         @Test
         void findsCellTypeMarkerGeneFiles(@Value("${data.files.location}") String dataFilesLocation) {
-            String experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
-            DataFileHub subject = new DataFileHub(dataFilesPath.resolve("scxa"));
+            var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+            var subject = new DataFileHub(dataFilesPath.resolve("scxa"));
             LOGGER.info("Test cell type marker gene files for experiment {}", experimentAccession);
             assertThat(subject.getSingleCellExperimentFiles(experimentAccession).markerGeneTsvs.values()
                     .stream().map(path -> path.getPath()))
@@ -170,8 +170,8 @@ class DataFileHubIT {
 
         @Test
         void findsRawFilteredCountsFiles() {
-            String experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
-            DataFileHub subject = new DataFileHub(dataFilesPath.resolve("scxa"));
+            var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+            var subject = new DataFileHub(dataFilesPath.resolve("scxa"));
             LOGGER.info("Test raw filtered count files for experiment {}", experimentAccession);
             assertAtlasResourceExists(subject.getSingleCellExperimentFiles(experimentAccession).filteredCountsMatrix);
             assertAtlasResourceExists(subject.getSingleCellExperimentFiles(experimentAccession).filteredCountsGeneIdsTsv);
@@ -180,8 +180,8 @@ class DataFileHubIT {
 
         @Test
         void findsNormalisedCountsFiles() {
-            String experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
-            DataFileHub subject = new DataFileHub(dataFilesPath.resolve("scxa"));
+            var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+            var subject = new DataFileHub(dataFilesPath.resolve("scxa"));
             LOGGER.info("Test normalised filtered count files for experiment {}", experimentAccession);
             assertAtlasResourceExists(subject.getSingleCellExperimentFiles(experimentAccession).normalisedCountsMatrix);
             assertAtlasResourceExists(subject.getSingleCellExperimentFiles(experimentAccession).normalisedCountsGeneIdsTsv);

--- a/src/test/java/uk/ac/ebi/atlas/resource/DataFileHubIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/resource/DataFileHubIT.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.context.ContextConfiguration;
@@ -153,6 +154,17 @@ class DataFileHubIT {
             DataFileHub subject = new DataFileHub(dataFilesPath.resolve("scxa"));
             LOGGER.info("Test marker gene files for experiment {}", experimentAccession);
             assertAtlasResourceExists(subject.getSingleCellExperimentFiles(experimentAccession).markerGeneTsvs.values());
+        }
+
+        @Test
+        void findsCellTypeMarkerGeneFiles(@Value("${data.files.location}") String dataFilesLocation) {
+            String experimentAccession = "E-MTAB-5061";
+            DataFileHub subject = new DataFileHub(dataFilesPath.resolve("scxa"));
+            LOGGER.info("Test cell type marker gene files for experiment {}", experimentAccession);
+            assertThat(subject.getSingleCellExperimentFiles(experimentAccession).markerGeneTsvs.values()
+                    .stream().map(path -> path.getPath()))
+                    .contains(Path.of(dataFilesLocation +
+                            "/scxa/magetab/E-MTAB-5061/E-MTAB-5061.marker_genes_inferred_cell_type_-_ontology_labels.tsv"));
         }
 
         @Test


### PR DESCRIPTION
The {marker_gene_[numbers]} are already included in the archive, and this story is to add the files named like `maker_gene_inferred_cell_type_-_ontology_labels`, so I add a new matcher.