### PR TITLE
Change units of protein expression in baseline experiments

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/model/ExpressionUnit.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/ExpressionUnit.java
@@ -9,11 +9,11 @@ public interface ExpressionUnit {
         }
 
         enum Protein implements Absolute {
-            ANY;
+            PPB;
 
             @Override
             public String toString() {
-                return "";
+                return "parts per billion";
             }
         }
     }

--- a/src/main/java/uk/ac/ebi/atlas/profiles/json/ExternallyViewableProfilesList.java
+++ b/src/main/java/uk/ac/ebi/atlas/profiles/json/ExternallyViewableProfilesList.java
@@ -48,7 +48,7 @@ public class ExternallyViewableProfilesList<R extends ReportsGeneExpression,
                 dataColumns,
                 baselineExperimentProfile -> baselineExperimentProfile.getExperimentType().isRnaSeqBaseline() ?
                         ExpressionUnit.Absolute.Rna.TPM :
-                        ExpressionUnit.Absolute.Protein.ANY);
+                        ExpressionUnit.Absolute.Protein.PPB);
     }
 
     public JsonObject asJson() {

--- a/src/main/java/uk/ac/ebi/atlas/web/ProteomicsBaselineRequestPreferences.java
+++ b/src/main/java/uk/ac/ebi/atlas/web/ProteomicsBaselineRequestPreferences.java
@@ -20,6 +20,6 @@ public class ProteomicsBaselineRequestPreferences extends BaselineRequestPrefere
 
     @Override
     public ExpressionUnit.Absolute.Protein getUnit() {
-        return ExpressionUnit.Absolute.Protein.ANY;
+        return ExpressionUnit.Absolute.Protein.PPB;
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/model/ExpressionUnitTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/ExpressionUnitTest.java
@@ -22,7 +22,7 @@ class ExpressionUnitTest {
     void testUnitsForBaselineProteomics() {
         assertThat(
                 Arrays.stream(ExpressionUnit.Absolute.Protein.values()).map(ExpressionUnit.Absolute.Protein::toString))
-                .containsExactlyInAnyOrder("");
+                .containsExactlyInAnyOrder("parts per billion");
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/collections/BulkAnalyticsCollectionProxyTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/collections/BulkAnalyticsCollectionProxyTest.java
@@ -14,7 +14,7 @@ class BulkAnalyticsCollectionProxyTest {
 
     @Test
     void proteomicUnitsAndTpmsAreTheSameField() {
-        assertThat(BulkAnalyticsCollectionProxy.getExpressionLevelFieldNames(ExpressionUnit.Absolute.Protein.ANY))
+        assertThat(BulkAnalyticsCollectionProxy.getExpressionLevelFieldNames(ExpressionUnit.Absolute.Protein.PPB))
                 .isEqualTo(BulkAnalyticsCollectionProxy.getExpressionLevelFieldNames(ExpressionUnit.Absolute.Rna.TPM));
     }
 


### PR DESCRIPTION
This PR contains code changes to change protein expression units from `Any `to `PPB`. 
Simple PR for the review :).