### PR TITLE
Feature/178928604 enable access for private experiments

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentJsonService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentJsonService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
+import uk.ac.ebi.atlas.trader.ExperimentTraderDao;
 
 import java.util.Comparator;
 
@@ -32,11 +33,12 @@ public class ExperimentJsonService {
 
     private final ExperimentTrader experimentTrader;
     private final ExperimentJsonSerializer experimentJsonSerializer;
+    private final ExperimentTraderDao experimentTraderDao;
 
-    public ExperimentJsonService(ExperimentTrader experimentTrader,
-                                 ExperimentJsonSerializer experimentJsonSerializer) {
+    public ExperimentJsonService(ExperimentTrader experimentTrader, ExperimentJsonSerializer experimentJsonSerializer, ExperimentTraderDao experimentTraderDao) {
         this.experimentTrader = experimentTrader;
         this.experimentJsonSerializer = experimentJsonSerializer;
+        this.experimentTraderDao = experimentTraderDao;
     }
 
     public JsonObject getExperimentJson(String experimentAccession, String accessKey) {
@@ -52,5 +54,9 @@ public class ExperimentJsonService {
                         .thenComparing(Experiment::getDisplayName))
                 .map(experimentJsonSerializer::serialize)
                 .collect(toImmutableSet());
+    }
+
+    public ImmutableSet<String> fetchPrivateExperimentAccessions(){
+        return experimentTraderDao.fetchPrivateExperimentAccessions();
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentJsonService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentJsonService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
-import uk.ac.ebi.atlas.trader.ExperimentTraderDao;
 
 import java.util.Comparator;
 
@@ -33,12 +32,11 @@ public class ExperimentJsonService {
 
     private final ExperimentTrader experimentTrader;
     private final ExperimentJsonSerializer experimentJsonSerializer;
-    private final ExperimentTraderDao experimentTraderDao;
 
-    public ExperimentJsonService(ExperimentTrader experimentTrader, ExperimentJsonSerializer experimentJsonSerializer, ExperimentTraderDao experimentTraderDao) {
+    public ExperimentJsonService(ExperimentTrader experimentTrader,
+                                 ExperimentJsonSerializer experimentJsonSerializer) {
         this.experimentTrader = experimentTrader;
         this.experimentJsonSerializer = experimentJsonSerializer;
-        this.experimentTraderDao = experimentTraderDao;
     }
 
     public JsonObject getExperimentJson(String experimentAccession, String accessKey) {
@@ -54,9 +52,5 @@ public class ExperimentJsonService {
                         .thenComparing(Experiment::getDisplayName))
                 .map(experimentJsonSerializer::serialize)
                 .collect(toImmutableSet());
-    }
-
-    public ImmutableSet<String> fetchPrivateExperimentAccessions(){
-        return experimentTraderDao.fetchPrivateExperimentAccessions();
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
@@ -16,6 +16,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.stream.Collectors.joining;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createDoubleBoundRangeQuery;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createLowerBoundRangeQuery;
+import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createNegativeFilterQuery;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createOrBooleanQuery;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createUpperBoundRangeQuery;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
@@ -113,6 +114,11 @@ public class SolrQueryBuilder<T extends CollectionProxy<?>> {
 
     public SolrQueryBuilder<T> setNormalize(boolean normalize) {
         this.normalize = normalize;
+        return this;
+    }
+
+    public <U extends SchemaField<T>> SolrQueryBuilder<T> addNegativeFilterFieldByTerm(U field, Collection<String> values) {
+        fqClausesBuilder.add(createNegativeFilterQuery(field,values,normalize));
         return this;
     }
 

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryUtils.java
@@ -23,6 +23,7 @@ public class SolrQueryUtils {
     private static final String STANDARD_QUERY_PARSER_LOWER_BOUND_RANGE_QUERY_TEMPLATE = "%s:[%s TO *]";
     private static final String STANDARD_QUERY_PARSER_UPPER_BOUND_RANGE_QUERY_TEMPLATE = "%s:[* TO %s]";
     private static final String STANDARD_QUERY_PARSER_DOUBLE_BOUND_RANGE_QUERY_TEMPLATE = "%s:[%s TO %s]";
+    private static final String STANDARD_QUERY_PARSER_NEGATIVE_QUERY_FILTER_QUERY_TEMPLATE = "!%s:(%s)";
 
     private static String normalize(String str) {
         return "\"" + escapeQueryChars(str.trim()) + "\"";
@@ -30,6 +31,19 @@ public class SolrQueryUtils {
 
     public static String createOrBooleanQuery(SchemaField field, Collection<String> values) {
         return createOrBooleanQuery(field, values, true);
+    }
+
+    public static String createNegativeFilterQuery(SchemaField field, Collection<String> values, boolean normalize) {
+        return values.stream().anyMatch(StringUtils::isNotBlank) ?
+                String.format(
+                        STANDARD_QUERY_PARSER_NEGATIVE_QUERY_FILTER_QUERY_TEMPLATE,
+                        field.name(),
+                        values.stream()
+                                .filter(StringUtils::isNotBlank)
+                                .map(value -> normalize ? SolrQueryUtils.normalize(value) : value)
+                                .distinct()
+                                .collect(joining(" OR "))) :
+                String.format(STANDARD_QUERY_PARSER_EXCLUDE_FIELD_QUERY_TEMPLATE, field.name());
     }
 
     public static String createOrBooleanQuery(SchemaField field, Collection<String> values, boolean normalize) {

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryUtils.java
@@ -34,16 +34,14 @@ public class SolrQueryUtils {
     }
 
     public static String createNegativeFilterQuery(SchemaField field, Collection<String> values, boolean normalize) {
-        return values.stream().anyMatch(StringUtils::isNotBlank) ?
-                String.format(
+        return String.format(
                         STANDARD_QUERY_PARSER_NEGATIVE_QUERY_FILTER_QUERY_TEMPLATE,
                         field.name(),
                         values.stream()
                                 .filter(StringUtils::isNotBlank)
                                 .map(value -> normalize ? SolrQueryUtils.normalize(value) : value)
                                 .distinct()
-                                .collect(joining(" OR "))) :
-                String.format(STANDARD_QUERY_PARSER_EXCLUDE_FIELD_QUERY_TEMPLATE, field.name());
+                                .collect(joining(" OR ")));
     }
 
     public static String createOrBooleanQuery(SchemaField field, Collection<String> values, boolean normalize) {

--- a/src/main/java/uk/ac/ebi/atlas/testutils/JdbcUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/testutils/JdbcUtils.java
@@ -294,13 +294,21 @@ public class JdbcUtils {
 				plotMethod);
 		return parameterisation.get(0);
 	}
-	public String updatePublicExperimentAccessionToPrivate(String accession) {
-		return jdbcTemplate.queryForObject(
-				"UPDATE experiment SET private=TRUE WHERE accession=?",String.class);
+	public void updatePublicExperimentAccessionToPrivate(String accession) {
+				jdbcTemplate.update(
+						"UPDATE experiment SET private=TRUE WHERE accession=?",
+						accession);
 	}
 
-	public String updatePrivateExperimentAccessionToPublic(String accession) {
+	public void updatePrivateExperimentAccessionToPublic(String accession) {
+		jdbcTemplate.update(
+				"UPDATE experiment SET private=FLASE WHERE accession=?",accession);
+	}
+
+	public String fetchExperimentAccessKey(String accession) {
 		return jdbcTemplate.queryForObject(
-				"UPDATE experiment SET private=FLASE WHERE accession=?",String.class);
+				"SELECT access_key FROM Experiment WHERE accession=?",
+				String.class,
+				accession);
 	}
 }

--- a/src/main/java/uk/ac/ebi/atlas/testutils/JdbcUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/testutils/JdbcUtils.java
@@ -294,4 +294,13 @@ public class JdbcUtils {
 				plotMethod);
 		return parameterisation.get(0);
 	}
+	public String updatePublicExperimentAccessionToPrivate(String accession) {
+		return jdbcTemplate.queryForObject(
+				"UPDATE experiment SET private=TRUE WHERE accession=?",String.class);
+	}
+
+	public String updatePrivateExperimentAccessionToPublic(String accession) {
+		return jdbcTemplate.queryForObject(
+				"UPDATE experiment SET private=FLASE WHERE accession=?",String.class);
+	}
 }

--- a/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTraderDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTraderDao.java
@@ -31,4 +31,12 @@ public class ExperimentTraderDao {
                         ImmutableMap.of("experimentTypes", experimentTypeNames),
                         String.class));
     }
+
+    public ImmutableSet<String> fetchPrivateExperimentAccessions(){
+        return ImmutableSet.copyOf(
+                namedParameterJdbcTemplate.queryForList(
+                        "SELECT accession FROM experiment WHERE private=TRUE",
+                        ImmutableMap.of(),
+                        String.class));
+    }
 }

--- a/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTraderDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTraderDao.java
@@ -31,7 +31,7 @@ public class ExperimentTraderDao {
                         String.class));
     }
 
-    @Cacheable("experimentAccessions")
+    @Cacheable("privateExperimentAccessions")
     public ImmutableSet<String> fetchPrivateExperimentAccessions(){
         return ImmutableSet.copyOf(
                 namedParameterJdbcTemplate.queryForList(

--- a/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTraderDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTraderDao.java
@@ -2,10 +2,9 @@ package uk.ac.ebi.atlas.trader;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
-import org.springframework.stereotype.Service;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import java.util.stream.Stream;
 
@@ -32,6 +31,7 @@ public class ExperimentTraderDao {
                         String.class));
     }
 
+    @Cacheable("experimentAccessions")
     public ImmutableSet<String> fetchPrivateExperimentAccessions(){
         return ImmutableSet.copyOf(
                 namedParameterJdbcTemplate.queryForList(

--- a/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTraderDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ExperimentTraderDao.java
@@ -4,12 +4,14 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
-@Component
+@Repository
 public class ExperimentTraderDao {
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 

--- a/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonServiceTest.java
@@ -30,9 +30,6 @@ public class ExperimentJsonServiceTest {
     @Mock
     private ExperimentJsonSerializer experimentJsonSerializerMock;
 
-    @Mock
-    private ExperimentTraderDao experimentTraderDaoMock;
-
     private ExperimentJsonService subject;
 
     @Before
@@ -44,7 +41,7 @@ public class ExperimentJsonServiceTest {
         when(experimentJsonSerializerMock.serialize(experiment))
                 .thenReturn(getMockSerializedExperiment(experiment));
 
-        subject = new ExperimentJsonService(experimentTraderMock, experimentJsonSerializerMock, experimentTraderDaoMock);
+        subject = new ExperimentJsonService(experimentTraderMock, experimentJsonSerializerMock);
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentJsonServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.testutils.MockExperiment;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
+import uk.ac.ebi.atlas.trader.ExperimentTraderDao;
 
 import java.text.SimpleDateFormat;
 import java.util.List;
@@ -29,6 +30,9 @@ public class ExperimentJsonServiceTest {
     @Mock
     private ExperimentJsonSerializer experimentJsonSerializerMock;
 
+    @Mock
+    private ExperimentTraderDao experimentTraderDaoMock;
+
     private ExperimentJsonService subject;
 
     @Before
@@ -40,7 +44,7 @@ public class ExperimentJsonServiceTest {
         when(experimentJsonSerializerMock.serialize(experiment))
                 .thenReturn(getMockSerializedExperiment(experiment));
 
-        subject = new ExperimentJsonService(experimentTraderMock, experimentJsonSerializerMock);
+        subject = new ExperimentJsonService(experimentTraderMock, experimentJsonSerializerMock, experimentTraderDaoMock);
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/trader/ExperimentTraderDaoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/trader/ExperimentTraderDaoIT.java
@@ -71,11 +71,15 @@ class ExperimentTraderDaoIT {
     }
 
     @Test
-    void getPrivateExperimentAccessions(){
+    void shouldGetPrivateExperimentAccessionsIfAvailable() {
         String accession = jdbcTestUtils.fetchRandomExperimentAccession();
         jdbcTestUtils.updatePublicExperimentAccessionToPrivate(accession);
         assertThat(subject.fetchPrivateExperimentAccessions()).isNotEmpty();
         jdbcTestUtils.updatePrivateExperimentAccessionToPublic(accession);
+    }
+
+    @Test
+    void shouldGetEmptyIfNoPrivateExperimentsCanBeFound() {
         assertThat(subject.fetchPrivateExperimentAccessions()).isEmpty();
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/trader/ExperimentTraderDaoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/trader/ExperimentTraderDaoIT.java
@@ -12,6 +12,7 @@ import org.springframework.test.jdbc.JdbcTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 import uk.ac.ebi.atlas.configuration.TestConfig;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
+import uk.ac.ebi.atlas.testutils.JdbcUtils;
 
 import javax.inject.Inject;
 
@@ -28,6 +29,9 @@ class ExperimentTraderDaoIT {
 
     @Inject
     private JdbcTemplate jdbcTemplate;
+
+    @Inject
+    private JdbcUtils jdbcTestUtils;
 
     @Inject
     private ExperimentTraderDao subject;
@@ -64,5 +68,14 @@ class ExperimentTraderDaoIT {
                             .isNotEmpty()
                             .size().isLessThan(
                                     JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "experiment", "private=FALSE")));
+    }
+
+    @Test
+    void getPrivateExperimentAccessions(){
+        String accession = jdbcTestUtils.fetchRandomExperimentAccession();
+        jdbcTestUtils.updatePublicExperimentAccessionToPrivate(accession);
+        assertThat(subject.fetchPrivateExperimentAccessions()).isNotEmpty();
+        jdbcTestUtils.updatePrivateExperimentAccessionToPublic(accession);
+        assertThat(subject.fetchPrivateExperimentAccessions()).isEmpty();
     }
 }


### PR DESCRIPTION
This feature allows users to see private experiments if they know the access key in the single cell.

Companion PR: [atlas-web-single-cell](https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/192)