### PR TITLE
Feature/175232742 add pdf file

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/StaticFilesDownload.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/StaticFilesDownload.java
@@ -23,6 +23,7 @@ public abstract class StaticFilesDownload<E extends Experiment> extends External
     private static final String URL_BASE = "experiments-content/{experimentAccession}/static/{experimentAccession}";
     private static final String R_DATA_URL = URL_BASE + "-atlasExperimentSummary.Rdata";
     private static final String HEATMAP_URL = URL_BASE + "-heatmap.pdf";
+    protected static final String SUMMARY_PDF_URL = "experiments-content/{experimentAccession}/static/{fileName}";
 
     public StaticFilesDownload(DataFileHub dataFileHub) {
         this.dataFileHub = dataFileHub;
@@ -59,6 +60,15 @@ public abstract class StaticFilesDownload<E extends Experiment> extends External
                             "Heatmap of aggregated expression data")));
         }
 
+        Path summaryPdf = dataFileHub.getExperimentFiles(experiment.getAccession()).summaryPdf.getPath();
+        if (summaryPdf.toFile().exists()) {
+            b.add(new ExternallyAvailableContent(
+                    SUMMARY_PDF_URL.replace("\\{experimentAccession}", experiment.getAccession())
+                                    .replace("\\{fileName}", summaryPdf.toFile().getName()),
+                    ExternallyAvailableContent.Description.create(
+                            "icon-pdf",
+                            "Summary pdf")));
+        }
         return b.build();
     }
 
@@ -73,6 +83,12 @@ public abstract class StaticFilesDownload<E extends Experiment> extends External
         @RequestMapping(value = HEATMAP_URL)
         public String downloadPdf(@PathVariable String experimentAccession) {
             String path = MessageFormat.format("/expdata/{0}/{0}-heatmap.pdf", experimentAccession);
+            return "forward:" + path;
+        }
+
+        @RequestMapping(value = SUMMARY_PDF_URL)
+        public String downloadSummaryPdf(@PathVariable String experimentAccession, @PathVariable String fileName) {
+            String path = MessageFormat.format("/expdata/{0}/{1}.pdf", experimentAccession, fileName);
             return "forward:" + path;
         }
     }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/StaticFilesDownload.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/StaticFilesDownload.java
@@ -36,13 +36,13 @@ public abstract class StaticFilesDownload<E extends Experiment> extends External
 
     @Override
     public Collection<ExternallyAvailableContent> get(E experiment) {
-        ImmutableList.Builder<ExternallyAvailableContent> b = ImmutableList.builder();
+        ImmutableList.Builder<ExternallyAvailableContent> externallyAvailableContentBuilder = ImmutableList.builder();
 
         Path rData = dataFileHub.getExperimentMageTabDirLocation()
                                 .resolve(experiment.getAccession())
                                 .resolve(experiment.getAccession() + "-atlasExperimentSummary.Rdata");
         if (rData.toFile().exists()) {
-            b.add(new ExternallyAvailableContent(
+            externallyAvailableContentBuilder.add(new ExternallyAvailableContent(
                     R_DATA_URL.replaceAll("\\{experimentAccession}", experiment.getAccession()),
                     ExternallyAvailableContent.Description.create(
                             "icon-Rdata",
@@ -53,7 +53,7 @@ public abstract class StaticFilesDownload<E extends Experiment> extends External
                                   .resolve(experiment.getAccession())
                                   .resolve(experiment.getAccession() + "-heatmap.pdf");
         if (heatmap.toFile().exists()) {
-            b.add(new ExternallyAvailableContent(
+            externallyAvailableContentBuilder.add(new ExternallyAvailableContent(
                     HEATMAP_URL.replaceAll("\\{experimentAccession}", experiment.getAccession()),
                     ExternallyAvailableContent.Description.create(
                             "icon-clustered-heatmap",
@@ -62,14 +62,14 @@ public abstract class StaticFilesDownload<E extends Experiment> extends External
 
         Path summaryPdf = dataFileHub.getExperimentFiles(experiment.getAccession()).summaryPdf.getPath();
         if (summaryPdf.toFile().exists()) {
-            b.add(new ExternallyAvailableContent(
+            externallyAvailableContentBuilder.add(new ExternallyAvailableContent(
                     SUMMARY_PDF_URL.replace("\\{experimentAccession}", experiment.getAccession())
                                     .replace("\\{fileName}", summaryPdf.toFile().getName()),
                     ExternallyAvailableContent.Description.create(
                             "icon-pdf",
                             "Summary pdf")));
         }
-        return b.build();
+        return externallyAvailableContentBuilder.build();
     }
 
     @Controller

--- a/src/main/java/uk/ac/ebi/atlas/model/ExpressionUnit.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/ExpressionUnit.java
@@ -9,11 +9,11 @@ public interface ExpressionUnit {
         }
 
         enum Protein implements Absolute {
-            ANY;
+            PPB;
 
             @Override
             public String toString() {
-                return "";
+                return "parts per billion";
             }
         }
     }

--- a/src/main/java/uk/ac/ebi/atlas/profiles/json/ExternallyViewableProfilesList.java
+++ b/src/main/java/uk/ac/ebi/atlas/profiles/json/ExternallyViewableProfilesList.java
@@ -48,7 +48,7 @@ public class ExternallyViewableProfilesList<R extends ReportsGeneExpression,
                 dataColumns,
                 baselineExperimentProfile -> baselineExperimentProfile.getExperimentType().isRnaSeqBaseline() ?
                         ExpressionUnit.Absolute.Rna.TPM :
-                        ExpressionUnit.Absolute.Protein.ANY);
+                        ExpressionUnit.Absolute.Protein.PPB);
     }
 
     public JsonObject asJson() {

--- a/src/main/java/uk/ac/ebi/atlas/web/ProteomicsBaselineRequestPreferences.java
+++ b/src/main/java/uk/ac/ebi/atlas/web/ProteomicsBaselineRequestPreferences.java
@@ -20,6 +20,6 @@ public class ProteomicsBaselineRequestPreferences extends BaselineRequestPrefere
 
     @Override
     public ExpressionUnit.Absolute.Protein getUnit() {
-        return ExpressionUnit.Absolute.Protein.ANY;
+        return ExpressionUnit.Absolute.Protein.PPB;
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/model/ExpressionUnitTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/ExpressionUnitTest.java
@@ -22,7 +22,7 @@ class ExpressionUnitTest {
     void testUnitsForBaselineProteomics() {
         assertThat(
                 Arrays.stream(ExpressionUnit.Absolute.Protein.values()).map(ExpressionUnit.Absolute.Protein::toString))
-                .containsExactlyInAnyOrder("");
+                .containsExactlyInAnyOrder("parts per billion");
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/collections/BulkAnalyticsCollectionProxyTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/collections/BulkAnalyticsCollectionProxyTest.java
@@ -14,7 +14,7 @@ class BulkAnalyticsCollectionProxyTest {
 
     @Test
     void proteomicUnitsAndTpmsAreTheSameField() {
-        assertThat(BulkAnalyticsCollectionProxy.getExpressionLevelFieldNames(ExpressionUnit.Absolute.Protein.ANY))
+        assertThat(BulkAnalyticsCollectionProxy.getExpressionLevelFieldNames(ExpressionUnit.Absolute.Protein.PPB))
                 .isEqualTo(BulkAnalyticsCollectionProxy.getExpressionLevelFieldNames(ExpressionUnit.Absolute.Rna.TPM));
     }
 


### PR DESCRIPTION
Add a pdf file named with `MaxQuant_Summary_ExpressionAtlas_labelFree.pdf` or `MaxQuant_Summary_ExpressionAtlas.pdf` in some proteomistic experiment local file folder. There might be other ways to add file, but I found that adding to static file class was more straightforward.

If you would like to test the functionality on your local server, please add a pdf file with proper filename under an experiment folder `/Users/[yourname]/ATLAS.DATA/filesystem/gxa/magetab/[experimentaccession]/`.

This PR comes with [atlas-web-bulk](https://github.com/ebi-gene-expression-group/atlas-web-bulk/compare/feature/175232742-add-pdf-file-to-download-tab)

