### PR TITLE
Feature/175873830 scxa analytics suggesters for search box

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterDao.java
@@ -7,5 +7,5 @@ import java.util.stream.Stream;
 
 public interface AnalyticsSuggesterDao {
 
-    Stream<Suggestion> fetchOntologyAnnotationSuggestions(String query, int limit, Species... species);
+    Stream<Suggestion> fetchMetaDataSuggestions(String query, int limit, Species... species);
 }

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterDao.java
@@ -1,0 +1,11 @@
+package uk.ac.ebi.atlas.search.suggester;
+
+import org.apache.solr.client.solrj.response.Suggestion;
+import uk.ac.ebi.atlas.species.Species;
+
+import java.util.stream.Stream;
+
+public interface AnalyticsSuggesterDao {
+
+    Stream<Suggestion> fetchOntologyAnnotationSuggestions(String query, int limit, Species... species);
+}

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterService.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import java.util.Map;
 import java.util.stream.Stream;
 
-@Service
+
 public interface AnalyticsSuggesterService {
     Stream<Map<String, String>> fetchOntologyAnnotationSuggestions(String query, String... species);
 }

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterService.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterService.java
@@ -1,9 +1,11 @@
 package uk.ac.ebi.atlas.search.suggester;
 
+import org.springframework.stereotype.Service;
+
 import java.util.Map;
 import java.util.stream.Stream;
 
+@Service
 public interface AnalyticsSuggesterService {
-
     Stream<Map<String, String>> fetchOntologyAnnotationSuggestions(String query, String... species);
 }

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterService.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterService.java
@@ -7,5 +7,5 @@ import java.util.stream.Stream;
 
 
 public interface AnalyticsSuggesterService {
-    Stream<Map<String, String>> fetchOntologyAnnotationSuggestions(String query, String... species);
+    Stream<Map<String, String>> fetchMetaDataSuggestions(String query, String... species);
 }

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterService.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterService.java
@@ -1,0 +1,9 @@
+package uk.ac.ebi.atlas.search.suggester;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+public interface AnalyticsSuggesterService {
+
+    Stream<Map<String, String>> fetchOntologyAnnotationSuggestions(String query, String... species);
+}

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapter.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapter.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.search.suggester;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonArray;
 import uk.ac.ebi.atlas.utils.GsonProvider;
@@ -45,5 +46,15 @@ public class SolrSuggestionReactSelectAdapter {
                                             "options", groupedSuggestions.get(propertyName.name)))));
 
         return jsonArray;
+    }
+
+    public static Map<String,List<ImmutableList<String>>> metaDataSerialize(Stream<Map<String, String>> suggestions) {
+        // get("label") returns a String ; get("value") returns a Map (the entry itself)
+        var groupedSuggestions =
+                suggestions.sorted(Comparator.comparing(suggestion -> (suggestion.get("term"))))
+                        .collect(groupingBy(suggestion -> suggestion.get("category"),
+                                mapping(suggestion -> ImmutableList.of("Options:", suggestion.get("term")),
+                                        toList())));
+        return groupedSuggestions;
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapter.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapter.java
@@ -55,7 +55,7 @@ public class SolrSuggestionReactSelectAdapter {
                         .collect(groupingBy(suggestion -> suggestion.get("category"),
                                 mapping(suggestion -> ImmutableList.of(
                                         "label", suggestion.get("term"),
-                                        "value", GsonProvider.GSON.toJson(suggestion)),
+                                        "options", GsonProvider.GSON.toJson(suggestion)),
                                         toList())));
         return groupedSuggestions;
     }

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapter.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapter.java
@@ -48,12 +48,14 @@ public class SolrSuggestionReactSelectAdapter {
         return jsonArray;
     }
 
-    public static Map<String,List<ImmutableList<String>>> metaDataSerialize(Stream<Map<String, String>> suggestions) {
+    public static Map<String, List<ImmutableList<String>>> metaDataSerialize(Stream<Map<String, String>> suggestions) {
         // get("label") returns a String ; get("value") returns a Map (the entry itself)
         var groupedSuggestions =
-                suggestions.sorted(Comparator.comparing(suggestion -> (suggestion.get("term"))))
+                suggestions.sorted(Comparator.comparing(suggestion -> suggestion.get("term")))
                         .collect(groupingBy(suggestion -> suggestion.get("category"),
-                                mapping(suggestion -> ImmutableList.of("Options:", suggestion.get("term")),
+                                mapping(suggestion -> ImmutableList.of(
+                                        "label", suggestion.get("term"),
+                                        "value", GsonProvider.GSON.toJson(suggestion)),
                                         toList())));
         return groupedSuggestions;
     }

--- a/src/test/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapterTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapterTest.java
@@ -98,6 +98,23 @@ class SolrSuggestionReactSelectAdapterTest {
                 .containsExactly(results);
     }
 
+    @Test
+    void metaDataSuggestionsAreGroupedByCategory(Stream<Map<String, String>> suggestions) {
+        Map<String, String> suggestionA = ImmutableMap.of("term", "term a", "category", "category a");
+        Map<String, String> suggestionB = ImmutableMap.of("term", "term b", "category", "category b");
+        Map<String, String> suggestionC = ImmutableMap.of("term", "term c", "category", "category c");
+
+        List<Map<String, String>> metaDataSuggestions = Lists.newArrayList(suggestionA, suggestionB, suggestionC);
+        Collections.shuffle(metaDataSuggestions);
+
+        Map<String, List<ImmutableList<String>>> results =  ImmutableMap.of("category a", List.of(
+                ImmutableList.of("label", suggestionA.get("term a"), "options", GSON.toJson(suggestionA)),
+                ImmutableList.of("label", suggestionB.get("term a"), "options", GSON.toJson(suggestionB)),
+                ImmutableList.of("label", suggestionC.get("term a"), "options", GSON.toJson(suggestionC))));
+
+        assertThat(SolrSuggestionReactSelectAdapter.metaDataSerialize(metaDataSuggestions.stream()).get("term")).isNotEmpty();
+    }
+
     private static Stream<Arguments> idPropertyNameProvider() {
         ArrayList<BioentityPropertyName> idPropertyNames = new ArrayList<>(ID_PROPERTY_NAMES);
         Collections.shuffle(idPropertyNames);


### PR DESCRIPTION
This PR is about - Scxa analytics metadata suggestions implementation. This feature allows users to see suggestions for the organism, organism part, disease, and cell types in the gene search box.

Associated PR of scxa - [https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/199](https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/199)