### PR TITLE
Chore – Add OpenAPI documentation

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/configuration/BasePathsConfig.java
+++ b/src/main/java/uk/ac/ebi/atlas/configuration/BasePathsConfig.java
@@ -48,16 +48,19 @@ public class BasePathsConfig {
         return bioentityPropertiesDirPath().resolve("interpro.term-id-type.tsv");
     }
 
+    @Profile("cli")
     @Bean
     public Path annotationsDirPath() {
         return bioentityPropertiesDirPath().resolve("annotations");
     }
 
+    @Profile("cli")
     @Bean
     public Path arrayDesignsDirPath() {
         return bioentityPropertiesDirPath().resolve("array_designs");
     }
 
+    @Profile("cli")
     @Bean
     public Path reactomeDirPath() {
         return bioentityPropertiesDirPath().resolve("reactome");


### PR DESCRIPTION
Don’t initialise beans that are only needed for the CLI. This allows fewer files to launch SCXA, which are never used by the web app.

Companion PR of https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/214.