### PR TITLE
Provision for observing failure from coexpression data from outside.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+Manual checks
+
+- [ ] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 

--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/coexpression/BaselineCoexpressionProfileLoader.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/coexpression/BaselineCoexpressionProfileLoader.java
@@ -27,7 +27,7 @@ public class BaselineCoexpressionProfileLoader {
     public void setDataFileHub(DataFileHub dataFileHub) {
         this.dataFileHub = dataFileHub;
     }
-    
+
     @Transactional(transactionManager = "txManager")
     public int loadBaselineCoexpressionsProfile(String experimentAccession) {
         // Keeps the default previous behaviour.

--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/coexpression/BaselineCoexpressionProfileLoader.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/coexpression/BaselineCoexpressionProfileLoader.java
@@ -52,7 +52,9 @@ public class BaselineCoexpressionProfileLoader {
                 LOGGER.error("Error reading coexpression file for experiment {}", experimentAccession);
                 LOGGER.error(e.getMessage(), e);
                 // Meant mostly for the CLI usage
-                throw e if (failOnFailure);
+                if (failOnFailure) {
+                    throw e;
+                }
             }
         }
 

--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/coexpression/BaselineCoexpressionProfileLoader.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/coexpression/BaselineCoexpressionProfileLoader.java
@@ -40,7 +40,7 @@ public class BaselineCoexpressionProfileLoader {
     }
 
     @Transactional(transactionManager = "txManager")
-    public int loadBaselineCoexpressionsProfile(String experimentAccession, boolean failOnFailure) throws IOException
+    public int loadBaselineCoexpressionsProfile(String experimentAccession, boolean failOnFailure) throws IOException {
         AtlasResource<CSVReader> coexpressions =
                 dataFileHub.getBaselineExperimentFiles(experimentAccession).coexpressions;
 

--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/coexpression/BaselineCoexpressionProfileLoader.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/coexpression/BaselineCoexpressionProfileLoader.java
@@ -27,9 +27,20 @@ public class BaselineCoexpressionProfileLoader {
     public void setDataFileHub(DataFileHub dataFileHub) {
         this.dataFileHub = dataFileHub;
     }
-
+    
     @Transactional(transactionManager = "txManager")
     public int loadBaselineCoexpressionsProfile(String experimentAccession) {
+        // Keeps the default previous behaviour.
+        try {
+            return loadBaselineCoexpressionsProfile(experimentAccession, false);
+        } catch (IOException e) {
+            // error has already been shown on the LOGGER.
+            return 0;
+        }
+    }
+
+    @Transactional(transactionManager = "txManager")
+    public int loadBaselineCoexpressionsProfile(String experimentAccession, boolean failOnFailure) throws IOException
         AtlasResource<CSVReader> coexpressions =
                 dataFileHub.getBaselineExperimentFiles(experimentAccession).coexpressions;
 
@@ -40,6 +51,8 @@ public class BaselineCoexpressionProfileLoader {
             } catch (IOException | IllegalStateException e) {
                 LOGGER.error("Error reading coexpression file for experiment {}", experimentAccession);
                 LOGGER.error(e.getMessage(), e);
+                // Meant mostly for the CLI usage
+                throw e if (failOnFailure);
             }
         }
 


### PR DESCRIPTION
Currently a failure to load coexpression data was mostly ignored and there was no way of letting the calling classes now if there was an error. I overloaded the method to keep the default case as it was for other sections of the code and provided a new variant of it that allows to specify whether the method should fail on an error (and throw the exception upstream). This is to avoid silent errors on the CLI side.