### PR TITLE
Use jdbc.max_pool_size to set size of max pool size

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/configuration/JdbcConfig.java
+++ b/src/main/java/uk/ac/ebi/atlas/configuration/JdbcConfig.java
@@ -24,8 +24,7 @@ public class JdbcConfig {
                       @Value("${jdbc.url}") String jdbcUrl,
                       @Value("${jdbc.username}") String jdbcUserName,
                       @Value("${jdbc.password}") String jdbcPassword,
-                      @Value("${jdbc.max_pool_size:#{20}}") Integer maxPoolSize
-                      ) {
+                      @Value("${jdbc.max_pool_size:20}") int maxPoolSize) {
         hikariConfig = new HikariConfig();
         hikariConfig.setMaximumPoolSize(maxPoolSize);
         hikariConfig.setDataSourceClassName("org.postgresql.ds.PGSimpleDataSource");


### PR DESCRIPTION
This PR makes the maximum size of the database connection pool configurable, while keeping the default of 20.

Manual checks

- [x] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here: https://github.com/ebi-gene-expression-group/atlas-web-bulk/pull/109
