### PR TITLE
Avoids using dedupe processor

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/CollectionProxy.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/CollectionProxy.java
@@ -78,7 +78,9 @@ public abstract class CollectionProxy<SELF extends CollectionProxy<?>> {
             waitingTime += retries * WAITING_TIME_BETWEEN_RETRIES;
             try {
                 var updateRequest = new UpdateRequest();
-                updateRequest.setParam("processor", requestProcessor);
+                if(requestProcessor != null) {
+                    updateRequest.setParam("processor", requestProcessor);
+                }
                 var updateResponse = process(updateRequest.add(docs));
                 LOGGER.info("Finished on {} attempt", ordinal(retries));
                 return updateResponse;

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/BulkAnalyticsCollectionProxy.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/BulkAnalyticsCollectionProxy.java
@@ -106,7 +106,7 @@ public class BulkAnalyticsCollectionProxy extends CollectionProxy<BulkAnalyticsC
     }
 
     public UpdateResponse add(Collection<SolrInputDocument> docs) {
-        return super.add(docs, "dedupe");
+        return super.add(docs, null);
     }
 
     public FieldStatsInfo fieldStats(SchemaField<BulkAnalyticsCollectionProxy> field, SolrQuery solrQuery) {


### PR DESCRIPTION
This PR avoids using the dedupe processor for analytics loading from the web app.

Manual checks

- [x] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
