### PR TITLE
Some potentially missing proteomics experiment types uses

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/solr/analytics/query/AnalyticsQueryClient.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/analytics/query/AnalyticsQueryClient.java
@@ -47,11 +47,12 @@ public class AnalyticsQueryClient {
 
     private static final String BASELINE_FILTER_QUERY =
             "(experiment_type:RNASEQ_MRNA_BASELINE AND expression_level:[0.5 TO *]) " +
-            "OR experiment_type:PROTEOMICS_BASELINE";
+            "OR experiment_type:PROTEOMICS_BASELINE OR experiment_type:PROTEOMICS_BASELINE_DIA";
 
     private static final String DIFFERENTIAL_FILTER_QUERY =
             "experiment_type:(" +
                     "RNASEQ_MRNA_DIFFERENTIAL " +
+                    "OR PROTEOMICS_DIFFERENTIAL " +
                     "OR MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL " +
                     "OR MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL " +
                     "OR MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL) " +


### PR DESCRIPTION
Looking for how to set the bioentities collection name, I run into a few places where I suspect the new proteomics experiment types (baseline_dia and differential) might need to be added. If these findings are all unneeded or irrelevant, please feel free to ignore and close this.

Manual checks

- [ ] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
