### PR TITLE
Feature ##181094330 – Change bioentities collection alias to atlas-bioentities

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/configuration/SolrConfig.java
+++ b/src/main/java/uk/ac/ebi/atlas/configuration/SolrConfig.java
@@ -17,7 +17,7 @@ public class SolrConfig {
     @Bean
     public SolrClient solrClientBioentities(@Value("${solr.host}") String solrHost,
                                             @Value("${solr.port}") String solrPort) {
-        return new HttpSolrClient.Builder("http://" + solrHost + ":" + solrPort + "/solr/bioentities").build();
+        return new HttpSolrClient.Builder("http://" + solrHost + ":" + solrPort + "/solr/atlas-bioentities").build();
     }
 
     @Bean

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/BioentitiesCollectionProxy.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/collections/BioentitiesCollectionProxy.java
@@ -49,7 +49,7 @@ public class BioentitiesCollectionProxy extends CollectionProxy<BioentitiesColle
             new BioentitiesSchemaField("property_value");
 
     public BioentitiesCollectionProxy(SolrClient solrClient) {
-        super(solrClient, "bioentities");
+        super(solrClient, "atlas-bioentities");
     }
 
     public static String asBioentitiesCollectionQuery(SemanticQueryTerm geneQuery) {


### PR DESCRIPTION
I think the changes are simplre. Just remember to create the `atlas-bioentities` alias in Solr. Companion PR of https://github.com/ebi-gene-expression-group/atlas-web-bulk/pull/113.

Manual checks

- [x] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
