### PR TITLE
Chore – Fix all failing tests in atlas-web-core

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityCardProperties.java
+++ b/src/main/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityCardProperties.java
@@ -23,35 +23,35 @@ public class BioEntityCardProperties {
     private static final Map<BioentityPropertyName, Function<Species, String>> PROPERTY_LINK_MAPPER =
             ImmutableMap.<BioentityPropertyName, Function<Species, String>>builder()
                     .put(ENSGENE,
-                            species -> species.isUnknown() ?
+                            species -> species.isUnknown() || species.getGenomeBrowsers().isEmpty() ?
                                     "" :
                                     species.getGenomeBrowsers().asList().get(0).get("url") + "/Gene/Summary?g={0}")
                     .put(WBPSGENE,
-                            species -> species.isUnknown() ?
+                            species -> species.isUnknown() || species.getGenomeBrowsers().isEmpty() ?
                                     "" :
                                     species.getGenomeBrowsers().asList().get(0).get("url") + "/Gene/Summary?g={0}")
                     .put(ENSTRANSCRIPT,
-                            species -> species.isUnknown() ?
+                            species -> species.isUnknown() || species.getGenomeBrowsers().isEmpty() ?
                                     "" :
                                     species.getGenomeBrowsers().asList().get(0).get("url") +
                                             "/Transcript/Summary?t={0}")
                     .put(WBPSTRANSCRIPT,
-                            species -> species.isUnknown() ?
+                            species -> species.isUnknown() || species.getGenomeBrowsers().isEmpty() ?
                                     "" :
                                     species.getGenomeBrowsers().asList().get(0).get("url") +
                                             "/Transcript/Summary?t={0}")
                     .put(ENSPROTEIN,
-                            species -> species.isUnknown() ?
+                            species -> species.isUnknown() || species.getGenomeBrowsers().isEmpty() ?
                                     "" :
                                     species.getGenomeBrowsers().asList().get(0).get("url") +
                                             "/Transcript/ProteinSummary?t={0}")
                     .put(WBPSPROTEIN,
-                            species -> species.isUnknown() ?
+                            species -> species.isUnknown() || species.getGenomeBrowsers().isEmpty() ?
                                     "" :
                                     species.getGenomeBrowsers().asList().get(0).get("url") +
                                             "/Transcript/ProteinSummary?t={0}")
                     .put(ENSFAMILY_DESCRIPTION,
-                            species -> species.isUnknown() ?
+                            species -> species.isUnknown() || species.getGenomeBrowsers().isEmpty() ?
                                     "" :
                                     species.getGenomeBrowsers().asList().get(0).get("url") +
                                             "/Gene/Family?g={1}")

--- a/src/main/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyDao.java
@@ -87,7 +87,11 @@ public class BioEntityPropertyDao {
                     .get()
                     .collect(toImmutableMap(
                             tuple -> tuple.getString("bioentity_identifier"),
-                            tuple -> tuple.getString("property_value")));
+                            tuple -> tuple.getString("property_value"),
+                            // Since there’s no guarantee that the collection doesn’t have duplicates because a
+                            // bioentity ID may have multiple values for the same property, we need to specify a
+                            // merge strategy
+                            (value1, value2) -> String.join("; ", value1, value2)));
         }
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/testutils/JdbcUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/testutils/JdbcUtils.java
@@ -295,14 +295,15 @@ public class JdbcUtils {
 		return parameterisation.get(0);
 	}
 	public void updatePublicExperimentAccessionToPrivate(String accession) {
-				jdbcTemplate.update(
-						"UPDATE experiment SET private=TRUE WHERE accession=?",
-						accession);
+		jdbcTemplate.update(
+				"UPDATE experiment SET private=TRUE WHERE accession=?",
+				accession);
 	}
 
 	public void updatePrivateExperimentAccessionToPublic(String accession) {
 		jdbcTemplate.update(
-				"UPDATE experiment SET private=FLASE WHERE accession=?",accession);
+				"UPDATE experiment SET private=FALSE WHERE accession=?",
+				accession);
 	}
 
 	public String fetchExperimentAccessKey(String accession) {

--- a/src/test/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityCardModelFactoryIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityCardModelFactoryIT.java
@@ -57,7 +57,7 @@ class BioEntityCardModelFactoryIT {
     void descriptionIsCleanedUp(String geneId) {
         var propertyValuesByType = bioentityPropertyDao.fetchGenePageProperties(geneId);
         var bioentityCardModel = subject.modelAttributes(
-                geneId, speciesFactory.create("Crocubot"),
+                geneId, speciesFactory.create("Crocubo"),
                 BIOENTITY_PROPERTY_NAMES, "", propertyValuesByType);
 
         assertThat(propertyValuesByType.get(DESCRIPTION).iterator().next()).contains("[");

--- a/src/test/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyDaoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/bioentity/properties/BioEntityPropertyDaoIT.java
@@ -72,7 +72,7 @@ class BioEntityPropertyDaoIT {
     }
 
     @Test
-    void validGeneIdsReturnAssociatedSymbols() {
+    void validGeneIdsReturnAssociatedSymbol() {
         List<String> geneIds = Arrays.asList("ENSG00000001626", "ENSMUSG00000033952", "ENSDARG00000103754");
 
         assertThat(subject.getSymbolsForGeneIds(geneIds))

--- a/src/test/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserIT.java
@@ -31,7 +31,7 @@ class IdfParserIT {
         private DataSource dataSource;
 
         @Inject
-        private Path dataFilesPath;
+        private Path experimentsDirPath;
 
         @Inject
         private JdbcUtils jdbcUtils;
@@ -53,7 +53,7 @@ class IdfParserIT {
         @ParameterizedTest
         @MethodSource("bulkExperimentsProvider")
         void testParserForExpressionAtlas(String experimentAccession) {
-            IdfParser idfParser = new IdfParser(new DataFileHub(dataFilesPath.resolve("gxa")));
+            IdfParser idfParser = new IdfParser(new DataFileHub(experimentsDirPath));
 
             IdfParserOutput result = idfParser.parse(experimentAccession);
 

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentConfigurationIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentConfigurationIT.java
@@ -39,7 +39,7 @@ class ExperimentConfigurationIT {
     private JdbcUtils jdbcUtils;
 
     @Inject
-    private Path dataFilesPath;
+    private Path experimentsDirPath;
 
     private ExperimentConfiguration subject;
 
@@ -61,7 +61,7 @@ class ExperimentConfigurationIT {
     @MethodSource("microArrayExperimentAccessionProvider")
     void testGetArrayDesignNames(String experimentAccession) {
         subject =
-                new ConfigurationTrader(new DataFileHub(dataFilesPath.resolve("gxa")))
+                new ConfigurationTrader(new DataFileHub(experimentsDirPath))
                         .getExperimentConfiguration(experimentAccession);
 
         assertThat(subject.getArrayDesignAccessions())

--- a/src/test/java/uk/ac/ebi/atlas/resource/DataFileHubIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/resource/DataFileHubIT.java
@@ -38,7 +38,7 @@ class DataFileHubIT {
         private DataSource dataSource;
 
         @Inject
-        private Path dataFilesPath;
+        private Path experimentsDirPath;
 
         @Inject
         private JdbcUtils jdbcUtils;
@@ -59,7 +59,7 @@ class DataFileHubIT {
 
         @Test
         void testGetExperimentFiles() {
-            var subject = new DataFileHub(dataFilesPath.resolve("gxa"));
+            var subject = new DataFileHub(experimentsDirPath);
             var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
             LOGGER.info("Test experiment files for experiment {}", experimentAccession);
 
@@ -70,7 +70,7 @@ class DataFileHubIT {
 
         @Test
         void testGetBaselineFiles() {
-            var subject = new DataFileHub(dataFilesPath.resolve("gxa"));
+            var subject = new DataFileHub(experimentsDirPath);
             var experimentAccession = jdbcUtils.fetchRandomExperimentAccession(ExperimentType.RNASEQ_MRNA_BASELINE);
             LOGGER.info("Test baseline experiment files for experiment {}", experimentAccession);
 
@@ -84,7 +84,7 @@ class DataFileHubIT {
 
         @Test
         void testGetProteomicsBaselineFiles() {
-            var subject = new DataFileHub(dataFilesPath.resolve("gxa"));
+            var subject = new DataFileHub(experimentsDirPath);
             var experimentAccession = jdbcUtils.fetchRandomExperimentAccession(ExperimentType.PROTEOMICS_BASELINE);
             LOGGER.info("Test proteomics baseline experiment files for experiment {}", experimentAccession);
 
@@ -93,7 +93,7 @@ class DataFileHubIT {
 
         @Test
         void testGetDifferentialExperimentFiles() {
-            var subject = new DataFileHub(dataFilesPath.resolve("gxa"));
+            var subject = new DataFileHub(experimentsDirPath);
             var experimentAccession = jdbcUtils.fetchRandomExperimentAccession(ExperimentType.RNASEQ_MRNA_DIFFERENTIAL);
             LOGGER.info("Test differential experiment files for experiment {}", experimentAccession);
 

--- a/src/test/java/uk/ac/ebi/atlas/species/SpeciesFactoryIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/species/SpeciesFactoryIT.java
@@ -1,25 +1,22 @@
 package uk.ac.ebi.atlas.species;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.ac.ebi.atlas.configuration.TestConfig;
 
 import javax.inject.Inject;
 
 import java.util.HashSet;
-import java.util.Set;
 
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = TestConfig.class)
-public class SpeciesFactoryIT {
+class SpeciesFactoryIT {
     @Inject
     private SpeciesFactory subject;
 
@@ -27,58 +24,62 @@ public class SpeciesFactoryIT {
     private SpeciesPropertiesTrader speciesPropertiesTrader;
 
     @Test
-    public void differentSpeciesSameProperties() {
-        Species oryzaJaponica = subject.create("Oryza sativa Japonica group");
-        Species oryzaIndica = subject.create("Oryza sativa Indica group");
+    void differentSpeciesSameProperties() {
+        var oryzaJaponica = subject.create("Oryza sativa Japonica group");
+        var oryzaIndica = subject.create("Oryza sativa Indica group");
 
-        assertThat(oryzaJaponica.isUnknown(), is(false));
-        assertThat(oryzaIndica.isUnknown(), is(false));
+        assertThat(oryzaJaponica.isUnknown()).isFalse();
+        assertThat(oryzaIndica.isUnknown()).isFalse();
 
-        assertThat(oryzaJaponica.getName(), is(not(oryzaIndica.getName())));
-        assertThat(oryzaJaponica.getReferenceName(), is(oryzaIndica.getReferenceName()));
-        assertThat(oryzaJaponica.getEnsemblName(), is(oryzaIndica.getEnsemblName()));
-        assertThat(oryzaJaponica.getDefaultQueryFactorType(), is(oryzaIndica.getDefaultQueryFactorType()));
-        assertThat(oryzaJaponica.getKingdom(), is(oryzaIndica.getKingdom()));
+        assertThat(oryzaJaponica.getName()).isNotEqualTo(oryzaIndica.getName());
+        assertThat(oryzaJaponica.getReferenceName()).isEqualTo(oryzaIndica.getReferenceName());
+        assertThat(oryzaJaponica.getEnsemblName()).isEqualTo(oryzaIndica.getEnsemblName());
+        assertThat(oryzaJaponica.getDefaultQueryFactorType()).isEqualTo(oryzaIndica.getDefaultQueryFactorType());
+        assertThat(oryzaJaponica.getKingdom()).isEqualTo(oryzaIndica.getKingdom());
 
-        assertThat(oryzaJaponica.isPlant(), is(true));
-        assertThat(oryzaIndica.isPlant(), is(true));
+        assertThat(oryzaJaponica.isPlant()).isTrue();
+        assertThat(oryzaIndica.isPlant()).isTrue();
     }
 
     @Test
-    public void speciesComeWithGenomeBrowsers() {
+    void speciesComeWithGenomeBrowsers() {
         // Currently this is the only resource we care about
-        assertThat(subject.create("homo sapiens").getGenomeBrowsers().size(), greaterThan(0));
+        assertThat(subject.create("homo sapiens").getGenomeBrowsers()).size().isGreaterThan(0);
     }
 
     @Test
-    public void unknownSpecies() {
-        assertThat(subject.create("foobar").isUnknown(), is(true));
+    void unknownSpeciesHasOnlyEnsemblName() {
+        assertThat(subject.create("foobar"))
+                .hasFieldOrPropertyWithValue("ensemblName", "Foobar")
+                .hasFieldOrPropertyWithValue("defaultQueryFactorType", "")
+                .hasFieldOrPropertyWithValue("kingdom", "")
+                .hasFieldOrPropertyWithValue("genomeBrowsers", ImmutableList.of());
     }
 
     @Test
-    public void emptySpecies() {
-        assertThat(subject.create("").isUnknown(), is(true));
+    void emptySpecies() {
+        assertThat(subject.create("").isUnknown()).isTrue();
     }
 
     @Test
-    public void nullSpecies() {
-        assertThat(subject.create(null).isUnknown(), is(true));
+    void nullSpecies() {
+        assertThat(subject.create(null).isUnknown()).isTrue();
     }
 
     @Test
-    public void createUnknownSpecies() {
-        assertThat(subject.createUnknownSpecies().isUnknown(), is(true));
+    void createUnknownSpecies() {
+        assertThat(subject.createUnknownSpecies().isUnknown()).isTrue();
     }
 
     @Test
     public void oneSpeciesIsHuman() {
-        Set<String> result = new HashSet<>();
-        for (SpeciesProperties speciesProperties : speciesPropertiesTrader.getAll()) {
+        var result = new HashSet<String>();
+        for (var speciesProperties : speciesPropertiesTrader.getAll()) {
             if (subject.create(speciesProperties.ensemblName()).isUs()) {
                 result.add(speciesProperties.ensemblName());
             }
         }
 
-        assertThat(result, hasSize(1));
+        assertThat(result).hasSize(1);
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/trader/ConfigurationTraderIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/trader/ConfigurationTraderIT.java
@@ -20,13 +20,13 @@ import static org.junit.Assert.assertThat;
 @ContextConfiguration(classes = TestConfig.class)
 public class ConfigurationTraderIT {
     @Inject
-    private Path dataFilesPath;
+    private Path experimentsDirPath;
 
     private ConfigurationTrader subject;
 
     @Before
     public void setUp() {
-        subject = new ConfigurationTrader(new DataFileHub(dataFilesPath.resolve("gxa")));
+        subject = new ConfigurationTrader(new DataFileHub(experimentsDirPath));
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/trader/ExperimentTraderDaoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/trader/ExperimentTraderDaoIT.java
@@ -70,9 +70,10 @@ class ExperimentTraderDaoIT {
                                     JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, "experiment", "private=FALSE")));
     }
 
+    @Sql({"/fixtures/gxa-experiment-fixture.sql", "/fixtures/scxa-experiment-fixture.sql"})
     @Test
     void shouldGetPrivateExperimentAccessionsIfAvailable() {
-        String accession = jdbcTestUtils.fetchRandomExperimentAccession();
+        var accession = jdbcTestUtils.fetchRandomExperimentAccession();
         jdbcTestUtils.updatePublicExperimentAccessionToPrivate(accession);
         assertThat(subject.fetchPrivateExperimentAccessions()).isNotEmpty();
         jdbcTestUtils.updatePrivateExperimentAccessionToPublic(accession);


### PR DESCRIPTION
There were a few failing tests in `atlas-web-core`, namely:
- ExperimentConfigurationIT
- ExperimentTraderDaoIT
- DataFileHubIT
- IdfParserIT
- BioEntityCardModelFactoryIT
- BioEntityPropertyDaoIT
- SpeciesFactoryIT
- ConfigurationTraderIT

Note that due to the fact of how we handle species and some init paths a bit of business logic needed some tweaking as well.

In order to verify that they all pass you may run:
```bash
docker-compose -f docker-compose-postgres-test.yml -f docker-compose-solrcloud.yml -f docker-compose-gradle.yml run --rm --service-ports gxa-gradle bash -c '
./gradlew :atlas-web-core:clean &&
./gradlew -PdataFilesLocation=/atlas-data -PexperimentFilesLocation=/bulk-experiments -PjdbcUrl=jdbc:postgresql://$POSTGRES_HOST:5432/$POSTGRES_DB -PjdbcUsername=$POSTGRES_USER -PjdbcPassword=$POSTGRES_PASSWORD -PzkHost=gxa-zk-1 -PsolrHost=gxa-solrcloud-1 :atlas-web-core:testClasses &&
./gradlew :atlas-web-core:test
```

Manual checks

- [x] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
