### PR TITLE
Feature #180493383 – Remove empty columns in the multiexperiment heatmap

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/search/baseline/BaselineExperimentProfilesList.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/baseline/BaselineExperimentProfilesList.java
@@ -5,15 +5,23 @@ import uk.ac.ebi.atlas.model.GeneProfilesList;
 
 import java.util.List;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class BaselineExperimentProfilesList extends GeneProfilesList<BaselineExperimentProfile> {
     public BaselineExperimentProfilesList() {
     }
 
     public List<FactorAcrossExperiments> getFactorsAcrossExperiments() {
-        TreeSet<FactorAcrossExperiments> result = new TreeSet<>();
-        for (BaselineExperimentProfile profile: this) {
-            result.addAll(profile.getConditions());
+        var result = new TreeSet<FactorAcrossExperiments>();
+        for (var baselineExperimentProfile : this) {
+            result.addAll(
+                    baselineExperimentProfile.getConditions()
+                            .stream()
+                            .filter(condition -> isNotBlank(condition.getId()))
+                            .collect(toImmutableList()));
         }
 
         return ImmutableList.copyOf(result);

--- a/src/test/java/uk/ac/ebi/atlas/search/baseline/BaselineExperimentProfilesListTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/search/baseline/BaselineExperimentProfilesListTest.java
@@ -1,46 +1,57 @@
 package uk.ac.ebi.atlas.search.baseline;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExpression;
 import uk.ac.ebi.atlas.model.experiment.sdrf.Factor;
 import uk.ac.ebi.atlas.model.experiment.sdrf.FactorSet;
 import uk.ac.ebi.atlas.testutils.MockExperiment;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateBlankString;
 
-public class BaselineExperimentProfilesListTest {
+class BaselineExperimentProfilesListTest {
     private String factorHeader = "type1";
 
     @Test
-    public void testGetFactorsAcrossExperiments() {
-        BaselineExperimentProfilesList result = new BaselineExperimentProfilesList();
+    void testGetFactorsAcrossExperiments() {
+        var result = new BaselineExperimentProfilesList();
 
-        BaselineExperimentProfile p1 =
-                new BaselineExperimentProfile(MockExperiment.createBaselineExperiment(), new FactorSet());
+        var p1 = new BaselineExperimentProfile(MockExperiment.createBaselineExperiment(), new FactorSet());
         p1.add(new FactorAcrossExperiments(new Factor(factorHeader, "v1")), new BaselineExpression(1.0));
         p1.add(new FactorAcrossExperiments(new Factor(factorHeader, "v2")), new BaselineExpression(2.0));
         result.add(p1);
-        assertThat(result.getFactorsAcrossExperiments().size(), is(2));
+        assertThat(result.getFactorsAcrossExperiments()).hasSize(2);
 
-        BaselineExperimentProfile p2 =
-                new BaselineExperimentProfile(MockExperiment.createBaselineExperiment(), new FactorSet());
+        var p2 = new BaselineExperimentProfile(MockExperiment.createBaselineExperiment(), new FactorSet());
         p2.add(new FactorAcrossExperiments(new Factor(factorHeader, "v1")), new BaselineExpression(1.0));
         p2.add(new FactorAcrossExperiments(new Factor(factorHeader, "v3")), new BaselineExpression(3.0));
         result.add(p2);
-        assertThat(result.getFactorsAcrossExperiments().size(), is(3));
+        assertThat(result.getFactorsAcrossExperiments()).hasSize(3);
     }
 
     @Test
-    public void zerosDoMakeItToTheList() {
-        BaselineExperimentProfilesList result = new BaselineExperimentProfilesList();
+    void zerosDoMakeItToTheList() {
+        var result = new BaselineExperimentProfilesList();
 
-        BaselineExperimentProfile p1 =
-                new BaselineExperimentProfile(MockExperiment.createBaselineExperiment(), new FactorSet());
+        var p1 = new BaselineExperimentProfile(MockExperiment.createBaselineExperiment(), new FactorSet());
         p1.add(new FactorAcrossExperiments(new Factor(factorHeader, "v1")), new BaselineExpression(1.0));
         p1.add(new FactorAcrossExperiments(new Factor(factorHeader, "v2")), new BaselineExpression(2.0));
         p1.add(new FactorAcrossExperiments(new Factor(factorHeader, "v3")), new BaselineExpression(0.0));
         result.add(p1);
-        assertThat(result.getFactorsAcrossExperiments().size(), is(3));
+        assertThat(result.getFactorsAcrossExperiments()).hasSize(3);
+    }
+
+    @Test
+    void assaysComposedOfSamplesWithEmptyAnnotationsAreRemovedFromTheProfiles() {
+        var result = new BaselineExperimentProfilesList();
+
+        var p1 = new BaselineExperimentProfile(MockExperiment.createBaselineExperiment(), new FactorSet());
+        p1.add(
+                new FactorAcrossExperiments(
+                        new Factor(factorHeader, generateBlankString())), new BaselineExpression(1.0));
+        p1.add(new FactorAcrossExperiments(new Factor(factorHeader, "v2")), new BaselineExpression(2.0));
+        p1.add(new FactorAcrossExperiments(new Factor(factorHeader, "v3")), new BaselineExpression(0.0));
+        result.add(p1);
+        assertThat(result.getFactorsAcrossExperiments()).hasSize(2);
     }
 }


### PR DESCRIPTION
In the end I didn’t apply the solution proposed in the ticket (a separate class that filters out the results) because it was easy enough to test, contrary to what I thought at first.

Manual checks

- [x] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
