### PR TITLE
Bugfix #181273703 – 400 error when downloading “All data” in baseline proteomics experiments

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/model/ExpressionUnitPropertyEditor.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/ExpressionUnitPropertyEditor.java
@@ -1,0 +1,14 @@
+package uk.ac.ebi.atlas.model;
+
+import java.beans.PropertyEditorSupport;
+
+public class ExpressionUnitPropertyEditor extends PropertyEditorSupport {
+   @Override
+    public void setAsText(String text)  {
+        if (text.equalsIgnoreCase("relative abundance")) {
+            setValue(ExpressionUnit.Absolute.Protein.RA);
+        } else {
+            setValue(ExpressionUnit.Absolute.Protein.PPB);
+        }
+    }
+}


### PR DESCRIPTION
Add a property editor to parse baseline proteomics units.

Companion PR of https://github.com/ebi-gene-expression-group/atlas-web-bulk/pull/123.

Manual checks

- [ ] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
