### PR TITLE
Reduce experiment design table max no of rows from 1000 to 500

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTable.java
+++ b/src/main/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTable.java
@@ -17,7 +17,7 @@ import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 // One idea: pass in a function to the constructor of experiment design, made from the list of contrasts or assay
 // groups, that does this instead
 public class ExperimentDesignTable {
-    public static final int JSON_TABLE_MAX_ROWS = 1000;
+    public static final int JSON_TABLE_MAX_ROWS = 500;
     private final Experiment<? extends ReportsGeneExpression> experiment;
 
     public ExperimentDesignTable(Experiment<? extends ReportsGeneExpression> experiment) {

--- a/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTableTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentDesignTableTest.java
@@ -86,7 +86,7 @@ class ExperimentDesignTableTest {
     }
 
     @Test
-    void jsonTableIsCappedAt1000Rows() {
+    void jsonTableIsCappedAt500Rows() {
         var scExperiment =
                 new ExperimentBuilder.SingleCellBaselineExperimentBuilder()
                         .withExperimentDesign(experimentDesignMock)


### PR DESCRIPTION
Manual checks

- [ ] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
