### PR TITLE
  Bugfix #182315539 - Add organism in payload field

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterDao.java
@@ -5,5 +5,5 @@ import uk.ac.ebi.atlas.species.Species;
 import java.util.stream.Stream;
 
 public interface AnalyticsSuggesterDao {
-    Stream<Suggestion> fetchMetaDataSuggestions(String query, int limit, Species... species);
+    Stream<Suggestion> fetchMetadataSuggestions(String query, int limit);
 }

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterService.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/AnalyticsSuggesterService.java
@@ -4,5 +4,5 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 public interface AnalyticsSuggesterService {
-    Stream<Map<String, String>> fetchMetaDataSuggestions(String query, String... species);
+    Stream<Map<String, String>> fetchMetadataSuggestions(String query, String... species);
 }

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/SuggesterService.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/SuggesterService.java
@@ -24,7 +24,9 @@ public class SuggesterService {
     private final SpeciesFactory speciesFactory;
     private final AnalyticsSuggesterService analyticsSuggesterService;
 
-    public SuggesterService(SuggesterDao suggesterDao, SpeciesFactory speciesFactory,AnalyticsSuggesterService analyticsSuggesterService) {
+    public SuggesterService(SuggesterDao suggesterDao,
+                            SpeciesFactory speciesFactory,
+                            AnalyticsSuggesterService analyticsSuggesterService) {
         this.suggesterDao = suggesterDao;
         this.speciesFactory = speciesFactory;
         this.analyticsSuggesterService = analyticsSuggesterService;
@@ -53,7 +55,7 @@ public class SuggesterService {
 
     public Stream<Map<String,String>> aggregateGeneIdAndMetadataSuggestions(String query, String...  species){
         var bioentitySuggestions = fetchPropertiesWithoutHighlighting(query, species);
-        var metaDataSuggestions = analyticsSuggesterService.fetchMetaDataSuggestions(query,species);
+        var metaDataSuggestions = analyticsSuggesterService.fetchMetadataSuggestions(query, species);
         return  Stream.concat(bioentitySuggestions, metaDataSuggestions);
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/solr/analytics/AnalyticsPropertyName.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/analytics/AnalyticsPropertyName.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 
 public enum AnalyticsPropertyName {
 
-    METADATA("metadata", "MetaData");
+    METADATA("metadata", "Metadata");
 
     private static final ImmutableMap<String, AnalyticsPropertyName> PROPERTIES_BY_NAME =
             ImmutableMap.copyOf(Arrays.stream(values()).collect(Collectors.toMap(v -> v.name, v -> v)));

--- a/src/main/java/uk/ac/ebi/atlas/testutils/RandomDataTestUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/testutils/RandomDataTestUtils.java
@@ -156,12 +156,21 @@ public class RandomDataTestUtils {
 
     public static Set<TSnePoint.Dto> generateRandomTSnePointDtosWithClusters(int n, int k) {
         Set<TSnePoint.Dto> tSnePointDtos = new HashSet<>(n);
+
+        var coveredKs = new HashSet<Integer>(k);
+
         while (tSnePointDtos.size() < n) {
+            var nextK = RNG.nextInt(1, k + 1);
+            while (coveredKs.size() < k && coveredKs.contains(nextK)) {
+                nextK = RNG.nextInt(1, k + 1);
+            }
+            coveredKs.add(nextK);
+
             tSnePointDtos.add(
                     TSnePoint.Dto.create(
                             RNG.nextDouble(),
                             RNG.nextDouble(),
-                            Integer.toString(RNG.nextInt(1, k + 1)),
+                            Integer.toString(nextK),
                             generateRandomRnaSeqRunId()));
         }
 

--- a/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterServiceTest.java
@@ -96,8 +96,8 @@ class SuggesterServiceTest {
     }
 
     @Test
-    void shouldSeeAggregatedMetaDataAndGeneIdSuggestions(){
-        when(analyticsSuggesterDaoMock.fetchMetaDataSuggestions(anyString(),anyInt(),any()))
+    void shouldSeeAggregatedMetadataAndGeneIdSuggestions(){
+        when(analyticsSuggesterDaoMock.fetchMetadataSuggestions(anyString(), anyInt()))
           .thenReturn(Stream.of(
             new Suggestion(randomAlphanumeric(10), 10, randomAlphabetic(10)),
             new Suggestion(randomAlphanumeric(10), 15, randomAlphabetic(10)),
@@ -105,9 +105,10 @@ class SuggesterServiceTest {
             new Suggestion(randomAlphanumeric(10), 10, randomAlphabetic(10))));
 
         assertThat(subject.aggregateGeneIdAndMetadataSuggestions(randomAlphanumeric(3), ""))
-          .allMatch(aggregatedSuggestions -> aggregatedSuggestions.containsKey("category")
-            && aggregatedSuggestions.containsKey("term"));
+          .allMatch(
+                  aggregatedSuggestions ->
+                          aggregatedSuggestions.containsKey("category") && aggregatedSuggestions.containsKey("term"));
         verify(suggesterDaoMock).fetchBioentityProperties(anyString(), anyInt(), eq(false), eq(null));
-        verify(analyticsSuggesterServiceMock).fetchMetaDataSuggestions(anyString(), eq(""));
+        verify(analyticsSuggesterServiceMock).fetchMetadataSuggestions(anyString(), eq(""));
     }
 }


### PR DESCRIPTION
To filter suggestions by species rather than using the `suggest.cfq` field we want to do it in the back end (see https://github.com/ebi-gene-expression-group/index-scxa/pull/37 for a more in-depth explanation).

The species argument has been removed from the DAO and a few improvements have been made here and there.

Companion PR of https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/243.