### PR TITLE
Bugfix #182329349 – Serialize bioentity and metadata suggestions in a single list

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapter.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapter.java
@@ -38,27 +38,17 @@ public class SolrSuggestionReactSelectAdapter {
                                                                 "value", GsonProvider.GSON.toJson(suggestion)),
                                                 toList())));
 
-        return  groupedSuggestions.keySet().contains("metadata")? getAnalyticsSuggestions(groupedSuggestions):
-                getBioentitySuggestions(groupedSuggestions);
-    }
-
-    private static JsonArray getBioentitySuggestions(Map<String, List<ImmutableMap<String, String>>> groupedSuggestions) {
-        var jsonArray = new JsonArray();
-        BIOENTITY_PROPERTY_NAMES.stream()
-                .filter(propertyName -> groupedSuggestions.containsKey(propertyName.name))
-                .forEach(propertyName -> jsonArray.add(GsonProvider.GSON.toJsonTree(
-                        ImmutableMap.of("label", propertyName.label,
-                                "options", groupedSuggestions.get(propertyName.name)))));
-        return jsonArray;
-    }
-
-    private static JsonArray getAnalyticsSuggestions(Map<String, List<ImmutableMap<String, String>>> groupedSuggestions) {
         var jsonArray = new JsonArray();
         ANALYTIC_SUGGESTER_LABELS.stream()
                 .filter(propertyName -> groupedSuggestions.containsKey(propertyName.name))
                 .forEach(propertyName -> jsonArray.add(GsonProvider.GSON.toJsonTree(
                         ImmutableMap.of("label", propertyName.label,
-                                    "options", groupedSuggestions.get(propertyName.name)))));
+                                "options", groupedSuggestions.get(propertyName.name)))));
+        BIOENTITY_PROPERTY_NAMES.stream()
+                .filter(propertyName -> groupedSuggestions.containsKey(propertyName.name))
+                .forEach(propertyName -> jsonArray.add(GsonProvider.GSON.toJsonTree(
+                        ImmutableMap.of("label", propertyName.label,
+                                "options", groupedSuggestions.get(propertyName.name)))));
         return jsonArray;
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/search/suggester/SuggesterService.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/suggester/SuggesterService.java
@@ -53,9 +53,9 @@ public class SuggesterService {
                 .map(SUGGESTION_TO_MAP);
     }
 
-    public Stream<Map<String,String>> aggregateGeneIdAndMetadataSuggestions(String query, String...  species){
+    public Stream<Map<String,String>> aggregateGeneIdAndMetadataSuggestions(String query, String...  species) {
         var bioentitySuggestions = fetchPropertiesWithoutHighlighting(query, species);
-        var metaDataSuggestions = analyticsSuggesterService.fetchMetadataSuggestions(query, species);
-        return  Stream.concat(bioentitySuggestions, metaDataSuggestions);
+        var metadataSuggestions = analyticsSuggesterService.fetchMetadataSuggestions(query, species);
+        return Stream.concat(bioentitySuggestions, metadataSuggestions);
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapterTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/search/suggester/SolrSuggestionReactSelectAdapterTest.java
@@ -58,7 +58,7 @@ class SolrSuggestionReactSelectAdapterTest {
     @ParameterizedTest
     @MethodSource("bioentityPropertyNameProvider")
     void groupsAreSortedByIdPrecedence(List<BioentityPropertyName> bioentityPropertyNames) {
-        List<Map<String, String>> suggestions =
+        ImmutableList<Map<String, String>> suggestions =
                 bioentityPropertyNames.stream()
                         .map(idPropertyName ->
                                 ImmutableMap.of("term", randomAlphanumeric(30), "category", idPropertyName.name))
@@ -91,7 +91,7 @@ class SolrSuggestionReactSelectAdapterTest {
                                 ImmutableMap.of("label", suggestionB.get("term"), "value", GSON.toJson(suggestionB)),
                                 ImmutableMap.of("label", suggestionC.get("term"), "value", GSON.toJson(suggestionC)))));
 
-        List<Map<String, String>> suggestions = Lists.newArrayList(suggestionA, suggestionB, suggestionC);
+        var suggestions = Lists.<Map<String, String>>newArrayList(suggestionA, suggestionB, suggestionC);
         Collections.shuffle(suggestions);
 
         assertThat(SolrSuggestionReactSelectAdapter.serialize(suggestions.stream()))
@@ -100,7 +100,7 @@ class SolrSuggestionReactSelectAdapterTest {
 
     @ParameterizedTest
     @MethodSource("analyticsPropertyNameProvider")
-    void metaDataSuggestionsAreGroupedByCategory(List<AnalyticsPropertyName> analyticsPropertyNames) {
+    void metadataSuggestionsAreGroupedByCategory(List<AnalyticsPropertyName> analyticsPropertyNames) {
         var suggestionA = ImmutableMap.of("term", "term a", "category", analyticsPropertyNames.get(0).name);
         var suggestionB = ImmutableMap.of("term", "term b", "category", analyticsPropertyNames.get(0).name);
         var suggestionC = ImmutableMap.of("term", "term c", "category", analyticsPropertyNames.get(0).name);
@@ -114,11 +114,16 @@ class SolrSuggestionReactSelectAdapterTest {
                                 ImmutableMap.of("label", suggestionB.get("term"), "value", GSON.toJson(suggestionB)),
                                 ImmutableMap.of("label", suggestionC.get("term"), "value", GSON.toJson(suggestionC)))));
 
-        List<Map<String, String>> suggestions = Lists.newArrayList(suggestionA, suggestionB, suggestionC);
+        var suggestions = Lists.<Map<String, String>>newArrayList(suggestionA, suggestionB, suggestionC);
         Collections.shuffle(suggestions);
 
         assertThat(SolrSuggestionReactSelectAdapter.serialize(suggestions.stream()))
                 .containsExactly(results);
+    }
+
+    @Test
+    void metadataAndBioentitySuggestionsAreCombined() {
+        // TODO
     }
 
     private static Stream<Arguments> bioentityPropertyNameProvider() {


### PR DESCRIPTION
There was an exclusive condition: either serialize metadata suggestions or bioentity suggestions, but we want both in a single list.