### PR TITLE
Bugfix #260 – Add double quotes to values of `experimentProjects`

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
+++ b/src/main/java/uk/ac/ebi/atlas/utils/UrlHelpers.java
@@ -86,7 +86,7 @@ public class UrlHelpers {
         return ServletUriComponentsBuilder
                 .fromCurrentContextPath()
                 .path("/experiments")
-                .query("experimentProjects={description}")
+                .query("experimentProjects=\"{description}\"")
                 .buildAndExpand(description)
                 .toUriString();
     }

--- a/src/test/java/uk/ac/ebi/atlas/utils/UrlHelpersIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/utils/UrlHelpersIT.java
@@ -116,7 +116,7 @@ class UrlHelpersIT {
     }
 
     @Test
-    @DisplayName("Experiment links without a host point at /experimentsd/{accession}")
+    @DisplayName("Experiment links without a host point at /experiments/{accession}")
     void experimentLink() throws Exception {
         var experimentAccession = generateRandomExperimentAccession();
         var label = randomAlphabetic(3, 20);
@@ -157,7 +157,7 @@ class UrlHelpersIT {
     }
 
     @Test
-    @DisplayName("Links to experiment collections are of the form /experiments?experimentProjects={project-name}")
+    @DisplayName("Links to experiment collections are of the form /experiments?experimentProjects=\"{project-name}\"")
     void experimentCollectionLinksHasTheRightShape() throws Exception {
         var label = randomAlphabetic(10, 15);
         var collectionDescription = randomAlphabetic(10, 20);
@@ -167,6 +167,6 @@ class UrlHelpersIT {
                 .hasValue(label);
         assertThat(new URL(result.getRight().orElseThrow()))
                 .hasPath("/experiments")
-                .hasParameter("experimentProjects", collectionDescription);
+                .hasParameter("experimentProjects", "\"" + collectionDescription + "\"");
     }
 }


### PR DESCRIPTION
Solves https://github.com/ebi-gene-expression-group/atlas-web-single-cell/issues/260.