### PR TITLE
Remove unneeded trailing slash from resource link

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
@@ -5,10 +5,6 @@ import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriBuilder;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
-import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
-import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
-import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
-import uk.ac.ebi.atlas.model.experiment.singlecell.SingleCellBaselineExperiment;
 
 import java.text.MessageFormat;
 import java.util.Collection;
@@ -22,8 +18,7 @@ public class LinkToEga {
                     .host("www.ebi.ac.uk")
                     .pathSegment("ega")
                     .pathSegment("studies")
-                    .pathSegment("{0}")
-                    .path("/");
+                    .pathSegment("{0}");
 
     private static final Function<String, String> formatLabelToEga =
             arrayAccession -> MessageFormat.format("EGA: {0}", arrayAccession);

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 
@@ -8,23 +9,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
 
 class LinkToEgaIT {
-    LinkToEga subject = new LinkToEga();
+    LinkToEga subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new LinkToEga();
+    }
 
     @Test
     void linksIfExperimentIsOnEga() {
-        var proteomicsBaselineExperiment =
+        var egaDataSetAccession = "EGAD4545";
+        var egaStudyAccession = "EGAS4546";
+        var secondaryAccessions = ImmutableList.of(egaDataSetAccession, egaStudyAccession);
+        var experiment =
                 new ExperimentBuilder.BaselineExperimentBuilder()
-                        .withSecondaryAccessions(ImmutableList.of("EGA4545", "EGAS4546"))
+                        .withSecondaryAccessions(secondaryAccessions)
                         .build();
 
-        // We can’t use URI::getPath because the redirect prefix messes it up :/
-        assertThat(subject.get(proteomicsBaselineExperiment))
+        assertThat(subject.get(experiment))
                 .anyMatch(externallyAvailableContent ->
-                        externallyAvailableContent.uri.toString().endsWith("EGA4545/"))
+                        externallyAvailableContent.uri.toString().endsWith(egaDataSetAccession))
                 .anyMatch(externallyAvailableContent ->
-                        externallyAvailableContent.uri.toString().endsWith("EGAS4546/"))
+                        externallyAvailableContent.uri.toString().endsWith(egaStudyAccession))
                 .anyMatch(externallyAvailableContent -> externallyAvailableContent.description.type().equals("icon-ega"))
-                .hasSize(2);
+                .hasSize(secondaryAccessions.size());
     }
 
     @Test
@@ -32,5 +40,4 @@ class LinkToEgaIT {
         assertThat(subject.contentType())
                 .isEqualTo(SUPPLEMENTARY_INFORMATION);
     }
-
 }


### PR DESCRIPTION
Related PR in `atlas-web-bulk`: [[QuickFix] Remove unneeded trailing slash from resource link #212](https://github.com/ebi-gene-expression-group/atlas-web-bulk/pull/212)

Manual checks

- [ ] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
