### PR TITLE
Refactor experiment's external resource handling

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/GenerateResourceLinks.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/GenerateResourceLinks.java
@@ -9,6 +9,8 @@ import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 
 import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -29,6 +31,37 @@ public class GenerateResourceLinks {
                         uriAccession.getLeft().toString(),
                         createIcon.apply(uriAccession.getRight())))
                 .collect(toImmutableList());
+    }
+
+    public static ImmutableList<ExternallyAvailableContent> getLinks(Experiment<?> experiment,
+                                                                     Map<String, String> resourceTypeMapping,
+                                                                     UriBuilder uriBuilder,
+                                                                     Function<String, ExternallyAvailableContent.Description> createIcon) {
+        if (noSecondaryAccession(experiment)) {
+            return ImmutableList.of();
+        }
+
+        return experiment.getSecondaryAccessions().stream()
+                .map(accession -> {
+                    var link = uriBuilder.build(getPathSegment(resourceTypeMapping, accession), accession);
+                    return isUriValid(link) ?
+                            new ExternallyAvailableContent(link.toString(), createIcon.apply(accession)) :
+                            null;
+                })
+                .filter(Objects::nonNull)
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    private static boolean noSecondaryAccession(Experiment<?> experiment) {
+        return experiment.getSecondaryAccessions() == null || experiment.getSecondaryAccessions().isEmpty();
+    }
+
+    private static String getPathSegment(Map<String, String> resourceTypeMapping, String accession) {
+        return resourceTypeMapping.entrySet().stream()
+                .filter(entry -> accession.matches(entry.getKey()))
+                .findFirst()
+                .map(Map.Entry::getValue)
+                .orElse("");
     }
 
     private static boolean isUriValid(@NotNull URI uri) {

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/GenerateResourceLinks.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/GenerateResourceLinks.java
@@ -1,7 +1,6 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriBuilder;
@@ -13,25 +12,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
 public class GenerateResourceLinks {
     private static final WebClient webClient = WebClient.create();
-
-    public static ImmutableList<ExternallyAvailableContent> getLinks(Experiment<?> experiment,
-                                                                     String regex,
-                                                                     UriBuilder uriBuilder,
-                                                                     Function<String, ExternallyAvailableContent.Description> createIcon) {
-        return experiment.getSecondaryAccessions().stream()
-                .parallel()
-                .filter(accession -> accession.matches(regex))
-                .map(accession -> Pair.of(uriBuilder.build(accession), accession))
-                .filter(uriAccession -> isUriValid(uriAccession.getLeft()))
-                .map(uriAccession -> new ExternallyAvailableContent(
-                        uriAccession.getLeft().toString(),
-                        createIcon.apply(uriAccession.getRight())))
-                .collect(toImmutableList());
-    }
 
     public static ImmutableList<ExternallyAvailableContent> getLinks(Experiment<?> experiment,
                                                                      Map<String, String> resourceTypeMapping,
@@ -65,16 +47,11 @@ public class GenerateResourceLinks {
     }
 
     private static boolean isUriValid(@NotNull URI uri) {
-        try {
-            return !webClient
-                    .get()
-                    .uri(uri)
-                    .exchange()
-                    .block()
-                    .statusCode()
-                    .isError();
-        } catch (Exception e) {
-            return false;
-        }
+        var response = webClient
+                .get()
+                .uri(uri)
+                .exchange()
+                .block();
+        return response != null && !response.statusCode().isError();
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpress.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpress.java
@@ -2,14 +2,12 @@ package uk.ac.ebi.atlas.experimentpage.link;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriBuilder;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
 
-import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.function.Function;
@@ -19,26 +17,23 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 @Component
 public class LinkToArrayExpress {
-    // You’ll get a 302 if the last slash is missing!
+
+    private final ResourceLinkGenerator resourceLinkGenerator;
+
+    public LinkToArrayExpress(ResourceLinkGenerator resourceLinkGenerator) {
+        this.resourceLinkGenerator = resourceLinkGenerator;
+    }
+
     private static final UriBuilder BIOSTUDIES_API_URI_BUILDER =
             new DefaultUriBuilderFactory().builder()
                     .scheme("https")
                     .host("www.ebi.ac.uk")
                     .pathSegment("biostudies")
                     .pathSegment("arrayexpress")
-                    .pathSegment("studies")
-                    .pathSegment("{0}");
-    private static final UriBuilder ARRAYS_URI_BUILDER =
-            new DefaultUriBuilderFactory().builder()
-                    .scheme("https")
-                    .host("www.ebi.ac.uk")
-                    .pathSegment("biostudies")
-                    .pathSegment("arrayexpress")
-                    .pathSegment("arrays")
-                    .pathSegment("{0}");
-    private static final WebClient webClient = WebClient.create();
+                    .pathSegment("{0}")
+                    .pathSegment("{1}");
 
-    private static final Function<Experiment, String> formatLabelToExperiment =
+    private static final Function<Experiment<?>, String> formatLabelToExperiment =
             e -> MessageFormat.format("ArrayExpress: experiment {0}", e.getAccession());
     private static final Function<String, String> formatLabelToArray =
             arrayAccession -> MessageFormat.format("ArrayExpress: array design {0}", arrayAccession);
@@ -46,7 +41,7 @@ public class LinkToArrayExpress {
     private static final Function<String, ExternallyAvailableContent.Description> createIcon =
             label -> ExternallyAvailableContent.Description.create("icon-ae", label);
 
-    private static final Function<Experiment, ExternallyAvailableContent.Description> createIconForExperiment =
+    private static final Function<Experiment<?>, ExternallyAvailableContent.Description> createIconForExperiment =
             formatLabelToExperiment.andThen(createIcon);
     private static final Function<String, ExternallyAvailableContent.Description> createIconForArray =
             formatLabelToArray.andThen(createIcon);
@@ -55,10 +50,11 @@ public class LinkToArrayExpress {
         return ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
     }
 
-    public Collection<ExternallyAvailableContent> get(Experiment experiment) {
+    public Collection<ExternallyAvailableContent> get(Experiment<?> experiment) {
+
         var externalLinkFromExperiment = Stream.of(experiment.getAccession())
-                .map(BIOSTUDIES_API_URI_BUILDER::build)
-                .filter(this::isUriValid)
+                .map(accession -> BIOSTUDIES_API_URI_BUILDER.build("studies", accession))
+                .filter(resourceLinkGenerator::isUriValid)
                 .map(uri -> new ExternallyAvailableContent(
                         uri.toString(),
                         createIconForExperiment.apply(experiment)));
@@ -67,8 +63,8 @@ public class LinkToArrayExpress {
                             externalLinkFromExperiment,
                             ((MicroarrayExperiment) experiment).getArrayDesignAccessions().stream()
                                     .parallel()
-                                    .map(accession -> Pair.of(ARRAYS_URI_BUILDER.build(accession), accession))
-                                    .filter(uriAccession -> isUriValid(uriAccession.getLeft()))
+                                    .map(accession -> Pair.of(BIOSTUDIES_API_URI_BUILDER.build("arrays", accession), accession))
+                                    .filter(uriAccession -> resourceLinkGenerator.isUriValid(uriAccession.getLeft()))
                                     .map(uriAccession -> new ExternallyAvailableContent(
                                             uriAccession.getLeft().toString(),
                                             createIconForArray.apply(uriAccession.getRight()))))
@@ -76,19 +72,5 @@ public class LinkToArrayExpress {
         }
 
          return externalLinkFromExperiment.collect(toImmutableList());
-    }
-
-    public boolean isUriValid(URI uri) {
-        try {
-            return !webClient
-                    .get()
-                    .uri(uri)
-                    .exchange()
-                    .block()
-                    .statusCode()
-                    .isError();
-        } catch (Exception e) {
-            return false;
-        }
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpress.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpress.java
@@ -1,17 +1,13 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriBuilder;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
-import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
-import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
-import uk.ac.ebi.atlas.model.experiment.singlecell.SingleCellBaselineExperiment;
 
 import java.net.URI;
 import java.text.MessageFormat;
@@ -40,16 +36,14 @@ public class LinkToArrayExpress {
                     .host("www.ebi.ac.uk")
                     .pathSegment("arrayexpress")
                     .pathSegment("experiments")
-                    .pathSegment("{0}")
-                    .path("/");
+                    .pathSegment("{0}");
     private static final UriBuilder ARRAYS_URI_BUILDER =
             new DefaultUriBuilderFactory().builder()
                     .scheme("https")
                     .host("www.ebi.ac.uk")
                     .pathSegment("arrayexpress")
                     .pathSegment("arrays")
-                    .pathSegment("{0}")
-                    .path("/");
+                    .pathSegment("{0}");
     private static final WebClient webClient = WebClient.create();
 
     private static final Function<Experiment, String> formatLabelToExperiment =
@@ -72,7 +66,7 @@ public class LinkToArrayExpress {
     public Collection<ExternallyAvailableContent> get(Experiment experiment) {
         var externalLinkFromExperiment = Stream.of(experiment.getAccession())
                 .map(accession -> Pair.of(EXPERIMENTS_URI_BUILDER.build(accession), BIOSTUDIES_API_URI_BUILDER.build(accession)))
-                .filter(pairOfLinks -> LinkToArrayExpress.isUriValid(pairOfLinks.getRight()))
+                .filter(pairOfLinks -> isUriValid(pairOfLinks.getRight()))
                 .map(Pair::getLeft)
                 .map(uri -> new ExternallyAvailableContent(
                         uri.toString(),
@@ -93,7 +87,7 @@ public class LinkToArrayExpress {
          return externalLinkFromExperiment.collect(toImmutableList());
     }
 
-    private static boolean isUriValid(@NotNull URI uri) {
+    public boolean isUriValid(URI uri) {
         try {
             return !webClient
                     .get()

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpress.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpress.java
@@ -25,22 +25,14 @@ public class LinkToArrayExpress {
                     .scheme("https")
                     .host("www.ebi.ac.uk")
                     .pathSegment("biostudies")
-                    .pathSegment("api")
-                    .pathSegment("v1")
-                    .pathSegment("studies")
-                    .pathSegment("{0}");
-    // You’ll get a 302 if the last slash is missing!
-    private static final UriBuilder EXPERIMENTS_URI_BUILDER =
-            new DefaultUriBuilderFactory().builder()
-                    .scheme("https")
-                    .host("www.ebi.ac.uk")
                     .pathSegment("arrayexpress")
-                    .pathSegment("experiments")
+                    .pathSegment("studies")
                     .pathSegment("{0}");
     private static final UriBuilder ARRAYS_URI_BUILDER =
             new DefaultUriBuilderFactory().builder()
                     .scheme("https")
                     .host("www.ebi.ac.uk")
+                    .pathSegment("biostudies")
                     .pathSegment("arrayexpress")
                     .pathSegment("arrays")
                     .pathSegment("{0}");
@@ -65,13 +57,12 @@ public class LinkToArrayExpress {
 
     public Collection<ExternallyAvailableContent> get(Experiment experiment) {
         var externalLinkFromExperiment = Stream.of(experiment.getAccession())
-                .map(accession -> Pair.of(EXPERIMENTS_URI_BUILDER.build(accession), BIOSTUDIES_API_URI_BUILDER.build(accession)))
-                .filter(pairOfLinks -> isUriValid(pairOfLinks.getRight()))
-                .map(Pair::getLeft)
+                .map(BIOSTUDIES_API_URI_BUILDER::build)
+                .filter(this::isUriValid)
                 .map(uri -> new ExternallyAvailableContent(
                         uri.toString(),
                         createIconForExperiment.apply(experiment)));
-        if(experiment.getType().isMicroarray()) {
+        if (experiment.getType().isMicroarray()) {
             return Stream.concat(
                             externalLinkFromExperiment,
                             ((MicroarrayExperiment) experiment).getArrayDesignAccessions().stream()

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
@@ -1,24 +1,38 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
+import com.google.common.collect.ImmutableList;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriBuilder;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 
+import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
+
+import static java.util.Map.entry;
 
 @Component
 public class LinkToEga {
+    private static final WebClient webClient = WebClient.create();
+
     private static final UriBuilder EGA_URI_BUILDER =
             new DefaultUriBuilderFactory().builder()
                     .scheme("https")
                     .host("www.ebi.ac.uk")
                     .pathSegment("ega")
-                    .pathSegment("studies")
-                    .pathSegment("{0}");
+                    .pathSegment("{0}")
+                    .pathSegment("{1}");
+    private static final Map<String, String> EGA_RESOURCE_TYPE_MAPPING = Map.ofEntries(
+            entry("EGAD.*", "datasets"),
+            entry("EGAS.*", "studies")
+    );
 
     private static final Function<String, String> formatLabelToEga =
             arrayAccession -> MessageFormat.format("EGA: {0}", arrayAccession);
@@ -34,7 +48,42 @@ public class LinkToEga {
     }
 
     public Collection<ExternallyAvailableContent> get(Experiment experiment) {
-        return GenerateResourceLinks.getLinks(experiment, "EGA.*", EGA_URI_BUILDER, createIconForEga);
+        return getLinks(experiment, EGA_RESOURCE_TYPE_MAPPING, EGA_URI_BUILDER, createIconForEga);
     }
 
+    public static ImmutableList<ExternallyAvailableContent> getLinks(Experiment<?> experiment,
+                                                                     Map<String, String> resourceTypeMapping,
+                                                                     UriBuilder uriBuilder,
+                                                                     Function<String, ExternallyAvailableContent.Description> createIcon) {
+        if (experiment.getSecondaryAccessions() == null || experiment.getSecondaryAccessions().isEmpty()) {
+            return ImmutableList.of();
+        }
+
+        return experiment.getSecondaryAccessions().stream()
+                .map(accession -> {
+                    String EGAPathSegment = resourceTypeMapping.entrySet().stream()
+                            .filter(entry -> accession.matches(entry.getKey()))
+                            .findFirst()
+                            .map(Map.Entry::getValue)
+                            .orElse("");
+                    var link = uriBuilder.build(EGAPathSegment, accession);
+                    return isUriValid(link) ? new ExternallyAvailableContent(link.toString(), createIcon.apply(accession)) : null;
+                })
+                .filter(Objects::nonNull)
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    private static boolean isUriValid(@NotNull URI uri) {
+        try {
+            return !webClient
+                    .get()
+                    .uri(uri)
+                    .exchange()
+                    .block()
+                    .statusCode()
+                    .isError();
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
@@ -55,22 +55,31 @@ public class LinkToEga {
                                                                      Map<String, String> resourceTypeMapping,
                                                                      UriBuilder uriBuilder,
                                                                      Function<String, ExternallyAvailableContent.Description> createIcon) {
-        if (experiment.getSecondaryAccessions() == null || experiment.getSecondaryAccessions().isEmpty()) {
+        if (noSecondaryAccession(experiment)) {
             return ImmutableList.of();
         }
 
         return experiment.getSecondaryAccessions().stream()
                 .map(accession -> {
-                    String EGAPathSegment = resourceTypeMapping.entrySet().stream()
-                            .filter(entry -> accession.matches(entry.getKey()))
-                            .findFirst()
-                            .map(Map.Entry::getValue)
-                            .orElse("");
-                    var link = uriBuilder.build(EGAPathSegment, accession);
-                    return isUriValid(link) ? new ExternallyAvailableContent(link.toString(), createIcon.apply(accession)) : null;
+                    var link = uriBuilder.build(getPathSegment(resourceTypeMapping, accession), accession);
+                    return isUriValid(link) ?
+                            new ExternallyAvailableContent(link.toString(), createIcon.apply(accession)) :
+                            null;
                 })
                 .filter(Objects::nonNull)
                 .collect(ImmutableList.toImmutableList());
+    }
+
+    private static boolean noSecondaryAccession(Experiment<?> experiment) {
+        return experiment.getSecondaryAccessions() == null || experiment.getSecondaryAccessions().isEmpty();
+    }
+
+    private static String getPathSegment(Map<String, String> resourceTypeMapping, String accession) {
+        return resourceTypeMapping.entrySet().stream()
+                .filter(entry -> accession.matches(entry.getKey()))
+                .findFirst()
+                .map(Map.Entry::getValue)
+                .orElse("");
     }
 
     private static boolean isUriValid(@NotNull URI uri) {

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
@@ -1,27 +1,20 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
-import com.google.common.collect.ImmutableList;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriBuilder;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 
-import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 
 import static java.util.Map.entry;
 
 @Component
 public class LinkToEga {
-    private static final WebClient webClient = WebClient.create();
-
     private static final UriBuilder EGA_URI_BUILDER =
             new DefaultUriBuilderFactory().builder()
                     .scheme("https")
@@ -48,51 +41,6 @@ public class LinkToEga {
     }
 
     public Collection<ExternallyAvailableContent> get(Experiment experiment) {
-        return getLinks(experiment, EGA_RESOURCE_TYPE_MAPPING, EGA_URI_BUILDER, createIconForEga);
-    }
-
-    public static ImmutableList<ExternallyAvailableContent> getLinks(Experiment<?> experiment,
-                                                                     Map<String, String> resourceTypeMapping,
-                                                                     UriBuilder uriBuilder,
-                                                                     Function<String, ExternallyAvailableContent.Description> createIcon) {
-        if (noSecondaryAccession(experiment)) {
-            return ImmutableList.of();
-        }
-
-        return experiment.getSecondaryAccessions().stream()
-                .map(accession -> {
-                    var link = uriBuilder.build(getPathSegment(resourceTypeMapping, accession), accession);
-                    return isUriValid(link) ?
-                            new ExternallyAvailableContent(link.toString(), createIcon.apply(accession)) :
-                            null;
-                })
-                .filter(Objects::nonNull)
-                .collect(ImmutableList.toImmutableList());
-    }
-
-    private static boolean noSecondaryAccession(Experiment<?> experiment) {
-        return experiment.getSecondaryAccessions() == null || experiment.getSecondaryAccessions().isEmpty();
-    }
-
-    private static String getPathSegment(Map<String, String> resourceTypeMapping, String accession) {
-        return resourceTypeMapping.entrySet().stream()
-                .filter(entry -> accession.matches(entry.getKey()))
-                .findFirst()
-                .map(Map.Entry::getValue)
-                .orElse("");
-    }
-
-    private static boolean isUriValid(@NotNull URI uri) {
-        try {
-            return !webClient
-                    .get()
-                    .uri(uri)
-                    .exchange()
-                    .block()
-                    .statusCode()
-                    .isError();
-        } catch (Exception e) {
-            return false;
-        }
+        return GenerateResourceLinks.getLinks(experiment, EGA_RESOURCE_TYPE_MAPPING, EGA_URI_BUILDER, createIconForEga);
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
@@ -40,7 +40,7 @@ public class LinkToEga {
         return ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
     }
 
-    public Collection<ExternallyAvailableContent> get(Experiment experiment) {
+    public Collection<ExternallyAvailableContent> get(Experiment<?> experiment) {
         return GenerateResourceLinks.getLinks(experiment, EGA_RESOURCE_TYPE_MAPPING, EGA_URI_BUILDER, createIconForEga);
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEga.java
@@ -41,6 +41,6 @@ public class LinkToEga {
     }
 
     public Collection<ExternallyAvailableContent> get(Experiment<?> experiment) {
-        return GenerateResourceLinks.getLinks(experiment, EGA_RESOURCE_TYPE_MAPPING, EGA_URI_BUILDER, createIconForEga);
+        return new ResourceLinkGenerator().getLinks(experiment, EGA_RESOURCE_TYPE_MAPPING, EGA_URI_BUILDER, createIconForEga);
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEna.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEna.java
@@ -40,7 +40,7 @@ public class LinkToEna {
         return ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
     }
 
-    public Collection<ExternallyAvailableContent> get(Experiment experiment) {
+    public Collection<ExternallyAvailableContent> get(Experiment<?> experiment) {
         return GenerateResourceLinks.getLinks(experiment, ENA_RESOURCE_TYPE_MAPPING, ENA_URI_BUILDER, createIconForEna);
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEna.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEna.java
@@ -8,7 +8,10 @@ import uk.ac.ebi.atlas.model.experiment.Experiment;
 
 import java.text.MessageFormat;
 import java.util.Collection;
+import java.util.Map;
 import java.util.function.Function;
+
+import static java.util.Map.entry;
 
 @Component
 public class LinkToEna {
@@ -17,9 +20,12 @@ public class LinkToEna {
                     .scheme("https")
                     .host("www.ebi.ac.uk")
                     .pathSegment("ena")
-                    .pathSegment("data")
-                    .pathSegment("view")
-                    .pathSegment("{0}");
+                    .pathSegment("browser")
+                    .pathSegment("{0}")
+                    .pathSegment("{1}");
+    private static final Map<String, String> ENA_RESOURCE_TYPE_MAPPING = Map.ofEntries(
+            entry("[DES]RP.*", "view")
+    );
 
     private static final Function<String, String> formatLabelToEna =
             arrayAccession -> MessageFormat.format("ENA: {0}", arrayAccession);
@@ -35,7 +41,6 @@ public class LinkToEna {
     }
 
     public Collection<ExternallyAvailableContent> get(Experiment experiment) {
-        return GenerateResourceLinks.getLinks(experiment, "[^G]*", ENA_URI_BUILDER, createIconForEna);
+        return GenerateResourceLinks.getLinks(experiment, ENA_RESOURCE_TYPE_MAPPING, ENA_URI_BUILDER, createIconForEna);
     }
-
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEna.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEna.java
@@ -41,6 +41,6 @@ public class LinkToEna {
     }
 
     public Collection<ExternallyAvailableContent> get(Experiment<?> experiment) {
-        return GenerateResourceLinks.getLinks(experiment, ENA_RESOURCE_TYPE_MAPPING, ENA_URI_BUILDER, createIconForEna);
+        return new ResourceLinkGenerator().getLinks(experiment, ENA_RESOURCE_TYPE_MAPPING, ENA_URI_BUILDER, createIconForEna);
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeo.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeo.java
@@ -5,14 +5,14 @@ import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriBuilder;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
-import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
-import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
-import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
-import uk.ac.ebi.atlas.model.experiment.singlecell.SingleCellBaselineExperiment;
+import uk.ac.ebi.atlas.model.experiment.sample.ReportsGeneExpression;
 
 import java.text.MessageFormat;
 import java.util.Collection;
+import java.util.Map;
 import java.util.function.Function;
+
+import static java.util.Map.entry;
 
 @Component
 public class LinkToGeo {
@@ -22,8 +22,11 @@ public class LinkToGeo {
                     .host("www.ncbi.nlm.nih.gov")
                     .pathSegment("geo")
                     .pathSegment("query")
-                    .pathSegment("acc.cgi")
-                    .queryParam("acc", "{0}");
+                    .pathSegment("{0}")
+                    .queryParam("acc", "{1}");
+    private static final Map<String, String> GEO_RESOURCE_TYPE_MAPPING = Map.ofEntries(
+            entry(".*G(SE|DS).*", "acc.cgi")
+    );
 
     private static final Function<String, String> formatLabelToGeo =
             arrayAccession -> MessageFormat.format("GEO: {0}", arrayAccession);
@@ -38,8 +41,8 @@ public class LinkToGeo {
         return ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
     }
 
-    public Collection<ExternallyAvailableContent> get(Experiment experiment) {
-        return GenerateResourceLinks.getLinks(experiment, "GSE.*", GEO_URI_BUILDER, createIconForGeo);
+    public Collection<ExternallyAvailableContent> get(Experiment<? extends ReportsGeneExpression> experiment) {
+        return GenerateResourceLinks.getLinks(experiment, GEO_RESOURCE_TYPE_MAPPING, GEO_URI_BUILDER, createIconForGeo);
     }
 
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeo.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeo.java
@@ -42,7 +42,7 @@ public class LinkToGeo {
     }
 
     public Collection<ExternallyAvailableContent> get(Experiment<? extends ReportsGeneExpression> experiment) {
-        return GenerateResourceLinks.getLinks(experiment, GEO_RESOURCE_TYPE_MAPPING, GEO_URI_BUILDER, createIconForGeo);
+        return new ResourceLinkGenerator().getLinks(experiment, GEO_RESOURCE_TYPE_MAPPING, GEO_URI_BUILDER, createIconForGeo);
     }
 
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToPride.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/LinkToPride.java
@@ -1,16 +1,14 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
 import com.google.common.collect.ImmutableSet;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
-import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
 
 import java.text.MessageFormat;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -24,15 +22,20 @@ public class LinkToPride {
     private static final Function<String, ExternallyAvailableContent.Description> createIcon =
             formatLabel.andThen(label -> ExternallyAvailableContent.Description.create("icon-pride", label));
 
-    public Collection<ExternallyAvailableContent> get(Experiment experiment) {
-        ImmutableSet<String> secondaryAccessions = experiment.getSecondaryAccessions();
+    public List<ExternallyAvailableContent> get(Experiment<?> experiment) {
+        var secondaryAccessions = experiment.getSecondaryAccessions();
 
-        if (!secondaryAccessions.isEmpty()) {
+        if (noSecondaryAccession(secondaryAccessions)) {
             return getExternallyAvailableContents(secondaryAccessions);
         } else {
             return emptyContent();
         }
     }
+
+    private boolean noSecondaryAccession(ImmutableSet<String> secondaryAccessions) {
+        return secondaryAccessions != null && !secondaryAccessions.isEmpty();
+    }
+
     @NotNull
     private static List<ExternallyAvailableContent> emptyContent() {
         return Collections.emptyList();

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/link/ResourceLinkGenerator.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/link/ResourceLinkGenerator.java
@@ -1,7 +1,7 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
 import com.google.common.collect.ImmutableList;
-import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriBuilder;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
@@ -12,10 +12,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-public class GenerateResourceLinks {
+@Component
+public class ResourceLinkGenerator {
     private static final WebClient webClient = WebClient.create();
 
-    public static ImmutableList<ExternallyAvailableContent> getLinks(Experiment<?> experiment,
+    public ImmutableList<ExternallyAvailableContent> getLinks(Experiment<?> experiment,
                                                                      Map<String, String> resourceTypeMapping,
                                                                      UriBuilder uriBuilder,
                                                                      Function<String, ExternallyAvailableContent.Description> createIcon) {
@@ -24,21 +25,26 @@ public class GenerateResourceLinks {
         }
 
         return experiment.getSecondaryAccessions().stream()
-                .map(accession -> {
-                    var link = uriBuilder.build(getPathSegment(resourceTypeMapping, accession), accession);
-                    return isUriValid(link) ?
-                            new ExternallyAvailableContent(link.toString(), createIcon.apply(accession)) :
-                            null;
-                })
+                .map(accession -> getResourceLink(resourceTypeMapping, uriBuilder, createIcon, accession))
                 .filter(Objects::nonNull)
                 .collect(ImmutableList.toImmutableList());
     }
 
-    private static boolean noSecondaryAccession(Experiment<?> experiment) {
+    private ExternallyAvailableContent getResourceLink(Map<String, String> resourceTypeMapping,
+                                                              UriBuilder uriBuilder,
+                                                              Function<String, ExternallyAvailableContent.Description> createIcon,
+                                                              String accession) {
+        var link = uriBuilder.build(getPathSegment(resourceTypeMapping, accession), accession);
+        return isUriValid(link) ?
+                new ExternallyAvailableContent(link.toString(), createIcon.apply(accession)) :
+                null;
+    }
+
+    private boolean noSecondaryAccession(Experiment<?> experiment) {
         return experiment.getSecondaryAccessions() == null || experiment.getSecondaryAccessions().isEmpty();
     }
 
-    private static String getPathSegment(Map<String, String> resourceTypeMapping, String accession) {
+    private String getPathSegment(Map<String, String> resourceTypeMapping, String accession) {
         return resourceTypeMapping.entrySet().stream()
                 .filter(entry -> accession.matches(entry.getKey()))
                 .findFirst()
@@ -46,7 +52,7 @@ public class GenerateResourceLinks {
                 .orElse("");
     }
 
-    private static boolean isUriValid(@NotNull URI uri) {
+    public boolean isUriValid(URI uri) {
         var response = webClient
                 .get()
                 .uri(uri)

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpressIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpressIT.java
@@ -23,7 +23,7 @@ import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentT
 
 class LinkToArrayExpressIT {
 
-    LinkToArrayExpress subject;
+    private LinkToArrayExpress subject;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpressIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpressIT.java
@@ -24,15 +24,18 @@ import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentT
 class LinkToArrayExpressIT {
 
     private LinkToArrayExpress subject;
+    private ResourceLinkGenerator mockResourceLinkGenerator;
 
     @BeforeEach
     void setUp() {
-        subject = Mockito.spy(LinkToArrayExpress.class);
+        mockResourceLinkGenerator = Mockito.mock(ResourceLinkGenerator.class);
+        subject = new LinkToArrayExpress(mockResourceLinkGenerator);
     }
 
     @Test
     void whenExperimentNotExistsInArrayExpress_thenNoLinksProvided() {
-        when(subject.isUriValid(any(URI.class))).thenReturn(Boolean.FALSE);
+        when(mockResourceLinkGenerator.isUriValid(any(URI.class))).thenReturn(Boolean.FALSE);
+
         var differentialExperiment = new ExperimentBuilder.DifferentialExperimentBuilder().build();
 
         assertThat(subject.get(differentialExperiment)).isEmpty();
@@ -40,18 +43,20 @@ class LinkToArrayExpressIT {
 
     @Test
     void whenMicroArrayExperimentNotExistsInArrayExpress_thenNoLinksProvided() {
-        when(subject.isUriValid(any(URI.class))).thenReturn(Boolean.FALSE);
+        when(mockResourceLinkGenerator.isUriValid(any(URI.class))).thenReturn(Boolean.FALSE);
         var microarrayExperiment =
                 new ExperimentBuilder.MicroarrayExperimentBuilder()
                         .withArrayDesigns(ImmutableList.of(ArrayDesign.create(randomAlphanumeric(10))))
                         .build();
 
-        assertThat(subject.get(microarrayExperiment)).isEmpty();
+        var resourceLinks = subject.get(microarrayExperiment);
+
+        assertThat(resourceLinks).isEmpty();
     }
 
     @Test
     void whenMicroArrayExperimentExistsInArrayExpress_thenCorrectLinksProvided() {
-        when(subject.isUriValid(any(URI.class))).thenReturn(Boolean.TRUE);
+        when(mockResourceLinkGenerator.isUriValid(any(URI.class))).thenReturn(Boolean.TRUE);
 
         var arrayDesignSize = 10;
         var linkTypes = Map.ofEntries(
@@ -96,4 +101,3 @@ class LinkToArrayExpressIT {
                         .build();
     }
 }
-

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpressIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpressIT.java
@@ -32,16 +32,20 @@ class LinkToArrayExpressIT {
 
     @Test
     void whenExperimentNotExistsInArrayExpress_thenNoLinksProvided() {
+        when(subject.isUriValid(any(URI.class))).thenReturn(Boolean.FALSE);
         var differentialExperiment = new ExperimentBuilder.DifferentialExperimentBuilder().build();
+
         assertThat(subject.get(differentialExperiment)).isEmpty();
     }
 
     @Test
     void whenMicroArrayExperimentNotExistsInArrayExpress_thenNoLinksProvided() {
+        when(subject.isUriValid(any(URI.class))).thenReturn(Boolean.FALSE);
         var microarrayExperiment =
                 new ExperimentBuilder.MicroarrayExperimentBuilder()
                         .withArrayDesigns(ImmutableList.of(ArrayDesign.create(randomAlphanumeric(10))))
                         .build();
+
         assertThat(subject.get(microarrayExperiment)).isEmpty();
     }
 
@@ -51,7 +55,7 @@ class LinkToArrayExpressIT {
 
         var arrayDesignSize = 10;
         var linkTypes = Map.ofEntries(
-                entry("E-MEXP", "experiments/"),
+                entry("E-MEXP", "studies/"),
                 entry("A-AFFY", "arrays/")
         );
         var microarrayExperiment = buildMicroarrayExperiment(arrayDesignSize);

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpressIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToArrayExpressIT.java
@@ -1,55 +1,95 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import uk.ac.ebi.atlas.model.arraydesign.ArrayDesign;
+import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
+import uk.ac.ebi.atlas.model.experiment.differential.microarray.MicroarrayExperiment;
 
+import java.net.URI;
+import java.util.Map;
+import java.util.Random;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Map.entry;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
 
 class LinkToArrayExpressIT {
-    LinkToArrayExpress subject = new LinkToArrayExpress();
+
+    LinkToArrayExpress subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = Mockito.spy(LinkToArrayExpress.class);
+    }
 
     @Test
-    void emptyLinkIfExperimentNotOnArrayExpress() {
+    void whenExperimentNotExistsInArrayExpress_thenNoLinksProvided() {
         var differentialExperiment = new ExperimentBuilder.DifferentialExperimentBuilder().build();
         assertThat(subject.get(differentialExperiment)).isEmpty();
     }
 
     @Test
-    void emptyLinkIfMicroarrayExperimentNotOnArrayExpress() {
+    void whenMicroArrayExperimentNotExistsInArrayExpress_thenNoLinksProvided() {
         var microarrayExperiment =
                 new ExperimentBuilder.MicroarrayExperimentBuilder()
-                        // This is what happens when our mock data is too close to real data
                         .withArrayDesigns(ImmutableList.of(ArrayDesign.create(randomAlphanumeric(10))))
                         .build();
         assertThat(subject.get(microarrayExperiment)).isEmpty();
     }
 
-    // Ideally we would pick a microarray experiment using JdbcUtils
     @Test
-    void linkIfMicroarrayExperimentIsOnArrayExpress() {
-        var microarrayExperiment =
-                new ExperimentBuilder.MicroarrayExperimentBuilder()
-                        .withExperimentAccession("E-MEXP-1968")
-                        .withArrayDesigns(ImmutableList.of(ArrayDesign.create("A-AFFY-45")))
-                        .build();
+    void whenMicroArrayExperimentExistsInArrayExpress_thenCorrectLinksProvided() {
+        when(subject.isUriValid(any(URI.class))).thenReturn(Boolean.TRUE);
 
-        // We can’t use URI::getPath because the redirect prefix messes it up :/
-        assertThat(subject.get(microarrayExperiment))
-                .anyMatch(externallyAvailableContent ->
-                        externallyAvailableContent.uri.toString().endsWith("/experiments/E-MEXP-1968/"))
-                .anyMatch(externallyAvailableContent ->
-                        externallyAvailableContent.uri.toString().endsWith("/arrays/A-AFFY-45/"))
-                .hasSize(2);
+        var arrayDesignSize = 10;
+        var linkTypes = Map.ofEntries(
+                entry("E-MEXP", "experiments/"),
+                entry("A-AFFY", "arrays/")
+        );
+        var microarrayExperiment = buildMicroarrayExperiment(arrayDesignSize);
+
+        var resourceLinks = subject.get(microarrayExperiment);
+
+        assertThat(resourceLinks).hasSize(arrayDesignSize + 1);
+        for (ExternallyAvailableContent resourceLink : resourceLinks) {
+            var link = resourceLink.uri.toString();
+            var accessionPrefixFromLink = link.substring(link.lastIndexOf("/") + 1)
+                    .substring(0, 6);
+            var pathSegmentType = linkTypes.get(accessionPrefixFromLink);
+            var expectedURLRegexp = ".*/arrayexpress/" + pathSegmentType + accessionPrefixFromLink + ".*";
+            assertThat(link).matches(expectedURLRegexp);
+        }
     }
 
     @Test
     void linksToArrayExpressShowInSupplementaryInformationTab() {
         assertThat(subject.contentType())
                 .isEqualTo(SUPPLEMENTARY_INFORMATION);
+    }
+
+    private MicroarrayExperiment buildMicroarrayExperiment(int arrayDesignsSize) {
+        Random rand = new Random();
+
+        var aeAccessionPrefix = "E-MEXP-";
+        var arrayDesignPrefix = "A-AFFY-";
+        var accession = aeAccessionPrefix + Math.abs(rand.nextInt());
+        var arrayDesigns = rand.ints(arrayDesignsSize, 1, 9999)
+                .mapToObj(postfix -> arrayDesignPrefix + postfix)
+                .map(ArrayDesign::create)
+                .collect(toImmutableList());
+
+        return new ExperimentBuilder.MicroarrayExperimentBuilder()
+                        .withExperimentAccession(accession)
+                        .withArrayDesigns(arrayDesigns)
+                        .build();
     }
 }
 

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.atlas.experimentpage.link;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,7 +18,7 @@ class LinkToEgaIT {
     }
 
     @Test
-    void linksIfExperimentIsOnEga() {
+    void givenLinksToExperiment_ThenAvailableResourcesContainsThoseLinks() {
         var egaDataSetAccession = "EGAD4545";
         var egaStudyAccession = "EGAS4546";
         var secondaryAccessions = ImmutableList.of(egaDataSetAccession, egaStudyAccession);
@@ -33,6 +34,23 @@ class LinkToEgaIT {
                         externallyAvailableContent.uri.toString().endsWith(egaStudyAccession))
                 .anyMatch(externallyAvailableContent -> externallyAvailableContent.description.type().equals("icon-ega"))
                 .hasSize(secondaryAccessions.size());
+    }
+
+    @Test
+    void givenExperimentHasEGADatasetResource_ThenAvailableResourcesContainsCorrectEGADatasetLink() {
+        var egaDataSetAccession = "EGAD4545";
+        var secondaryAccessions = ImmutableList.of(egaDataSetAccession);
+        var experiment = new ExperimentBuilder.BaselineExperimentBuilder()
+                .withSecondaryAccessions(secondaryAccessions)
+                .build();
+        var expectedURLEnding = "/ega/datasets/" + egaDataSetAccession;
+
+        var resourceLinks = subject.get(experiment);
+
+        assertThat(resourceLinks).hasSize(1);
+        for (ExternallyAvailableContent resourceLink : resourceLinks) {
+            assertThat(resourceLink.uri.toString()).endsWith(expectedURLEnding);
+        }
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
@@ -6,6 +6,12 @@ import org.junit.jupiter.api.Test;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
 
@@ -47,10 +53,58 @@ class LinkToEgaIT {
 
         var resourceLinks = subject.get(experiment);
 
-        assertThat(resourceLinks).hasSize(1);
+        assertThat(resourceLinks).hasSize(secondaryAccessions.size());
         for (ExternallyAvailableContent resourceLink : resourceLinks) {
             assertThat(resourceLink.uri.toString()).endsWith(expectedURLEnding);
         }
+    }
+
+    @Test
+    void givenExperimentHasMoreThan1EGADatasetResources_ThenAvailableResourcesContainsCorrectEGADatasetLinks() {
+        var egaDataSetAccession1 = "EGAD4545";
+        var egaDataSetAccession2 = "EGAD1234";
+        var secondaryAccessions = ImmutableList.of(egaDataSetAccession1, egaDataSetAccession2);
+        var experiment = new ExperimentBuilder.BaselineExperimentBuilder()
+                .withSecondaryAccessions(secondaryAccessions)
+                .build();
+        var expectedURLRegexp = ".*/ega/datasets/EGAD.*";
+
+        var resourceLinks = subject.get(experiment);
+
+        assertThat(resourceLinks).hasSize(secondaryAccessions.size());
+        for (ExternallyAvailableContent resourceLink : resourceLinks) {
+            assertThat(resourceLink.uri.toString()).matches(expectedURLRegexp);
+        }
+    }
+
+    @Test
+    void givenExperimentHasDifferentEGAResources_ThenAvailableResourcesContainsCorrectEGAResourceLinks() {
+        Random rand = new Random();
+
+        var secondaryAccessions = Stream.generate(() -> rand.nextBoolean() ? "D" : "S")
+                        .limit(100)
+                        .map(type -> "EGA" + type + rand.nextInt())
+                        .collect(toImmutableList());
+        var linkTypes = Map.ofEntries(
+                entry("EGAD", "/datasets/"),
+                entry("EGAS", "/studies/")
+        );
+        var experiment = new ExperimentBuilder.BaselineExperimentBuilder()
+                .withSecondaryAccessions(secondaryAccessions)
+                .build();
+
+        var resourceLinks = subject.get(experiment);
+
+        assertThat(resourceLinks).hasSize(secondaryAccessions.size());
+        for (ExternallyAvailableContent resourceLink : resourceLinks) {
+            var link = resourceLink.uri.toString();
+            var accessionPrefixFromLink = link.substring(link.lastIndexOf("/") + 1)
+                    .substring(0, 4);
+            var pathSegmentType = linkTypes.get(accessionPrefixFromLink);
+            var expectedURLRegexp = ".*/ega" + pathSegmentType + accessionPrefixFromLink + ".*";
+            assertThat(resourceLink.uri.toString()).matches(expectedURLRegexp);
+        }
+
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
@@ -86,8 +86,8 @@ class LinkToEgaIT {
                         .map(type -> "EGA" + type + rand.nextInt())
                         .collect(toImmutableList());
         var linkTypes = Map.ofEntries(
-                entry("EGAD", "/datasets/"),
-                entry("EGAS", "/studies/")
+                entry("EGAD", ".*/ega/datasets/"),
+                entry("EGAS", ".*/ega/studies/")
         );
         var experiment = new ExperimentBuilder.BaselineExperimentBuilder()
                 .withSecondaryAccessions(secondaryAccessions)
@@ -101,10 +101,10 @@ class LinkToEgaIT {
             var accessionPrefixFromLink = link.substring(link.lastIndexOf("/") + 1)
                     .substring(0, 4);
             var pathSegmentType = linkTypes.get(accessionPrefixFromLink);
-            var expectedURLRegexp = ".*/ega" + pathSegmentType + accessionPrefixFromLink + ".*";
-            assertThat(resourceLink.uri.toString()).matches(expectedURLRegexp);
+            var expectedURLRegexp = pathSegmentType + accessionPrefixFromLink + ".*";
+            assertThat(link).matches(expectedURLRegexp);
+            assertThat(resourceLink.description.type()).isEqualTo("icon-ega");
         }
-
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 
+import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
@@ -17,9 +18,10 @@ import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentT
 
 class LinkToEgaIT {
 
-    String EXPECTED_DESCRIPTION_TYPE = "icon-ega";
+    private static final String EXPECTED_DESCRIPTION_TYPE = "icon-ega";
+    private static final String EGA_RESOURCE_DESCRIPTION = "EGA: ";
 
-    LinkToEga subject;
+    private LinkToEga subject;
 
     @BeforeEach
     void setUp() {
@@ -82,16 +84,17 @@ class LinkToEgaIT {
     }
 
     @Test
-    void givenExperimentHasDifferentEGAResources_ThenAvailableResourcesContainsCorrectEGAResourceLinks() {
+    void givenExperimentHasDifferentEGAResources_ThenAvailableResourcesContainsCorrectEGAResourceLinks()
+            throws URISyntaxException {
         Random rand = new Random();
 
         var secondaryAccessions = Stream.generate(() -> rand.nextBoolean() ? "D" : "S")
                         .limit(20)
-                        .map(type -> "EGA" + type + rand.nextInt())
+                        .map(type -> "EGA" + type + Math.abs(rand.nextInt()))
                         .collect(toImmutableList());
         var linkTypes = Map.ofEntries(
-                entry("EGAD", ".*/ega/datasets/"),
-                entry("EGAS", ".*/ega/studies/")
+                entry("EGAD", "redirect:https://www.ebi.ac.uk/ega/datasets/"),
+                entry("EGAS", "redirect:https://www.ebi.ac.uk/ega/studies/")
         );
         var experiment = new ExperimentBuilder.BaselineExperimentBuilder()
                 .withSecondaryAccessions(secondaryAccessions)
@@ -102,12 +105,14 @@ class LinkToEgaIT {
         assertThat(resourceLinks).hasSize(secondaryAccessions.size());
         for (ExternallyAvailableContent resourceLink : resourceLinks) {
             var link = resourceLink.uri.toString();
-            var accessionPrefixFromLink = link.substring(link.lastIndexOf("/") + 1)
-                    .substring(0, 4);
+            var accessionFromLink = link.substring(link.lastIndexOf("/") + 1);
+            var accessionPrefixFromLink = accessionFromLink.substring(0, 4);
             var pathSegmentType = linkTypes.get(accessionPrefixFromLink);
-            var expectedURLRegexp = pathSegmentType + accessionPrefixFromLink + ".*";
-            assertThat(link).matches(expectedURLRegexp);
-            assertThat(resourceLink.description.type()).isEqualTo(EXPECTED_DESCRIPTION_TYPE);
+            var expectedURL = pathSegmentType + accessionFromLink;
+            ResourceLinkAssertionUtil.assertResourceLink(resourceLink,
+                    expectedURL,
+                    EXPECTED_DESCRIPTION_TYPE,
+                    EGA_RESOURCE_DESCRIPTION + accessionFromLink);
         }
     }
 

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEgaIT.java
@@ -16,6 +16,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
 
 class LinkToEgaIT {
+
+    String EXPECTED_DESCRIPTION_TYPE = "icon-ega";
+
     LinkToEga subject;
 
     @BeforeEach
@@ -34,12 +37,13 @@ class LinkToEgaIT {
                         .build();
 
         assertThat(subject.get(experiment))
+                .hasSize(secondaryAccessions.size())
                 .anyMatch(externallyAvailableContent ->
                         externallyAvailableContent.uri.toString().endsWith(egaDataSetAccession))
                 .anyMatch(externallyAvailableContent ->
                         externallyAvailableContent.uri.toString().endsWith(egaStudyAccession))
-                .anyMatch(externallyAvailableContent -> externallyAvailableContent.description.type().equals("icon-ega"))
-                .hasSize(secondaryAccessions.size());
+                .anyMatch(externallyAvailableContent -> externallyAvailableContent.description.type()
+                        .equals(EXPECTED_DESCRIPTION_TYPE));
     }
 
     @Test
@@ -82,7 +86,7 @@ class LinkToEgaIT {
         Random rand = new Random();
 
         var secondaryAccessions = Stream.generate(() -> rand.nextBoolean() ? "D" : "S")
-                        .limit(100)
+                        .limit(20)
                         .map(type -> "EGA" + type + rand.nextInt())
                         .collect(toImmutableList());
         var linkTypes = Map.ofEntries(
@@ -103,7 +107,7 @@ class LinkToEgaIT {
             var pathSegmentType = linkTypes.get(accessionPrefixFromLink);
             var expectedURLRegexp = pathSegmentType + accessionPrefixFromLink + ".*";
             assertThat(link).matches(expectedURLRegexp);
-            assertThat(resourceLink.description.type()).isEqualTo("icon-ega");
+            assertThat(resourceLink.description.type()).isEqualTo(EXPECTED_DESCRIPTION_TYPE);
         }
     }
 

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEnaIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEnaIT.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
@@ -13,8 +14,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
 
 class LinkToEnaIT {
-    LinkToEna subject = new LinkToEna();
 
+    String EXPECTED_DESCRIPTION_TYPE = "icon-ena";
+
+    LinkToEna subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new LinkToEna();
+    }
 
     @Test
     void givenLinksToExperiment_ThenAvailableResourcesContainsThoseLinks() {
@@ -30,7 +38,8 @@ class LinkToEnaIT {
                         externallyAvailableContent.uri.toString().endsWith(enaAccessions.get(0)))
                 .anyMatch(externallyAvailableContent ->
                         externallyAvailableContent.uri.toString().endsWith(enaAccessions.get(1)))
-                .anyMatch(externallyAvailableContent -> externallyAvailableContent.description.type().equals("icon-ena"));
+                .anyMatch(externallyAvailableContent -> externallyAvailableContent.description.type()
+                        .equals(EXPECTED_DESCRIPTION_TYPE));
     }
 
     @Test
@@ -39,7 +48,7 @@ class LinkToEnaIT {
 
         var secondaryAccessions =
                 Stream.generate(() -> rand.nextBoolean() ? "ERP" : rand.nextBoolean() ? "SRP" : "DRP")
-                        .limit(100)
+                        .limit(20)
                         .map(type -> type + Math.abs(rand.nextInt()))
                         .collect(toImmutableList());
         var pathSegment = ".*/ena/browser/view/";
@@ -57,7 +66,7 @@ class LinkToEnaIT {
                     .substring(0, 3);
             var expectedURLRegexp = pathSegment + accessionPrefixFromLink + ".*";
             assertThat(link).matches(expectedURLRegexp);
-            assertThat(resourceLink.description.type()).isEqualTo("icon-ena");
+            assertThat(resourceLink.description.type()).isEqualTo(EXPECTED_DESCRIPTION_TYPE);
         }
 
     }

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEnaIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEnaIT.java
@@ -1,9 +1,14 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
+import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
 
@@ -12,20 +17,49 @@ class LinkToEnaIT {
 
 
     @Test
-    void linksIfExperimentIsOnEna() {
+    void givenLinksToExperiment_ThenAvailableResourcesContainsThoseLinks() {
+        var enaAccessions= List.of("ERP4545", "ERP4546");
         var RnaSeqBaselineExperiment =
                 new ExperimentBuilder.BaselineExperimentBuilder()
-                        .withSecondaryAccessions(ImmutableList.of("ERP4545", "ERP4546"))
+                        .withSecondaryAccessions(enaAccessions)
                         .build();
 
-        // We can’t use URI::getPath because the redirect prefix messes it up :/
         assertThat(subject.get(RnaSeqBaselineExperiment))
+                .hasSize(enaAccessions.size())
                 .anyMatch(externallyAvailableContent ->
-                        externallyAvailableContent.uri.toString().endsWith("ERP4545"))
+                        externallyAvailableContent.uri.toString().endsWith(enaAccessions.get(0)))
                 .anyMatch(externallyAvailableContent ->
-                        externallyAvailableContent.uri.toString().endsWith("ERP4546"))
-                .anyMatch(externallyAvailableContent -> externallyAvailableContent.description.type().equals("icon-ena"))
-                .hasSize(2);
+                        externallyAvailableContent.uri.toString().endsWith(enaAccessions.get(1)))
+                .anyMatch(externallyAvailableContent -> externallyAvailableContent.description.type().equals("icon-ena"));
+    }
+
+    @Test
+    void givenExperimentHasDifferentENAResources_ThenAvailableResourcesContainsCorrectENAResourceLinks() {
+        Random rand = new Random();
+
+        var secondaryAccessions =
+                Stream.generate(() -> rand.nextBoolean() ? "ERP" : rand.nextBoolean() ? "SRP" : "DRP")
+                        .limit(100)
+                        .map(type -> type + Math.abs(rand.nextInt()))
+                        .collect(toImmutableList());
+        var pathSegment = ".*/ena/browser/view/";
+
+        var experiment = new ExperimentBuilder.BaselineExperimentBuilder()
+                .withSecondaryAccessions(secondaryAccessions)
+                .build();
+
+        var resourceLinks = subject.get(experiment);
+
+        assertThat(resourceLinks).hasSize(secondaryAccessions.size());
+        for (ExternallyAvailableContent resourceLink : resourceLinks) {
+            var link = resourceLink.uri.toString();
+            var accessionPrefixFromLink = link.substring(link.lastIndexOf("/") + 1)
+                    .substring(0, 3);
+            var expectedURLRegexp = pathSegment + accessionPrefixFromLink + ".*";
+            assertThat(link).matches(expectedURLRegexp);
+            assertThat(resourceLink.description.type()).isEqualTo("icon-ena");
+        }
+
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEnaIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToEnaIT.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
@@ -15,9 +16,10 @@ import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentT
 
 class LinkToEnaIT {
 
-    String EXPECTED_DESCRIPTION_TYPE = "icon-ena";
+    private static final String EXPECTED_DESCRIPTION_TYPE = "icon-ena";
+    private static final String ENA_RESOURCE_DESCRIPTION = "ENA: ";
 
-    LinkToEna subject;
+    private LinkToEna subject;
 
     @BeforeEach
     void setUp() {
@@ -43,7 +45,8 @@ class LinkToEnaIT {
     }
 
     @Test
-    void givenExperimentHasDifferentENAResources_ThenAvailableResourcesContainsCorrectENAResourceLinks() {
+    void givenExperimentHasDifferentENAResources_ThenAvailableResourcesContainsCorrectENAResourceLinks()
+            throws URISyntaxException {
         Random rand = new Random();
 
         var secondaryAccessions =
@@ -51,7 +54,7 @@ class LinkToEnaIT {
                         .limit(20)
                         .map(type -> type + Math.abs(rand.nextInt()))
                         .collect(toImmutableList());
-        var pathSegment = ".*/ena/browser/view/";
+        var pathSegment = "redirect:https://www.ebi.ac.uk/ena/browser/view/";
 
         var experiment = new ExperimentBuilder.BaselineExperimentBuilder()
                 .withSecondaryAccessions(secondaryAccessions)
@@ -62,13 +65,13 @@ class LinkToEnaIT {
         assertThat(resourceLinks).hasSize(secondaryAccessions.size());
         for (ExternallyAvailableContent resourceLink : resourceLinks) {
             var link = resourceLink.uri.toString();
-            var accessionPrefixFromLink = link.substring(link.lastIndexOf("/") + 1)
-                    .substring(0, 3);
-            var expectedURLRegexp = pathSegment + accessionPrefixFromLink + ".*";
-            assertThat(link).matches(expectedURLRegexp);
-            assertThat(resourceLink.description.type()).isEqualTo(EXPECTED_DESCRIPTION_TYPE);
+            var accessionFromLink = link.substring(link.lastIndexOf("/") + 1);
+            var expectedURL = pathSegment + accessionFromLink;
+            ResourceLinkAssertionUtil.assertResourceLink(resourceLink,
+                    expectedURL,
+                    EXPECTED_DESCRIPTION_TYPE,
+                    ENA_RESOURCE_DESCRIPTION + accessionFromLink);
         }
-
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeneIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeneIT.java
@@ -3,12 +3,13 @@ package uk.ac.ebi.atlas.experimentpage.link;
 import org.junit.Test;
 import uk.ac.ebi.atlas.model.Profile;
 
-import static org.hamcrest.Matchers.endsWith;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class LinkToGeneIT {
-    class DummyProfile extends Profile {
+    static class DummyProfile extends Profile {
         DummyProfile(String id, String name) {
             super(id, name);
         }
@@ -22,23 +23,22 @@ public class LinkToGeneIT {
     // Not comprehensive, if gene IDs need to use any of the following chars we need to use a URLEncoder
     private static final String[] ILLEGAL_CHARS = {"%", "^", "|", "<", ">", "`", "\"", "\\", "[", "]", "{", "}"};
 
-    private LinkToGene<DummyProfile> subject = new LinkToGene<>();
+    private final LinkToGene<DummyProfile> subject = new LinkToGene<>();
 
     // The hash will be set by the view, see search-results.jsp
     @Test
-    public void linksAtNoSpecificTab() {
-        assertThat(subject.apply(new DummyProfile("geneId", "geneName")).toString(), endsWith("geneId"));
+    public void givenGeneLinksToExperiment_ThenAvailableResourcesContainsThoseLinks() {
+        assertThat(subject.apply(new DummyProfile("geneId", "geneName")).toString()).endsWith("geneId");
     }
 
     @Test
     public void uriSyntaxExceptionsAreWrapped() {
         for (String illegalChar: ILLEGAL_CHARS) {
-            try {
-                subject.apply(new DummyProfile(illegalChar, ""));
-                fail("Did not throw:" + illegalChar);
-            } catch (RuntimeException e) {
-                //yum
-            }
+            assertThatExceptionOfType(RuntimeException.class).isThrownBy(
+                    () -> subject.apply(new DummyProfile(illegalChar, ""))
+            )
+                    .withCauseExactlyInstanceOf(URISyntaxException.class)
+                    .withMessageEndingWith("at index 6: genes/" + illegalChar);
         }
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeoIT.java
@@ -1,30 +1,80 @@
 package uk.ac.ebi.atlas.experimentpage.link;
 
-import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
 
 class LinkToGeoIT {
-    LinkToGeo subject = new LinkToGeo();
+
+    String EXPECTED_DESCRIPTION_TYPE = "icon-geo";
+
+    LinkToGeo subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new LinkToGeo();
+    }
 
     @Test
-    void linksIfExperimentIsOnGeo() {
+    void givenLinksToExperiment_ThenAvailableResourcesContainsThoseLinks() {
+        var secondaryAccessions = List.of("GSE150361", "GSE5454");
         var differentialExperiment =
                 new ExperimentBuilder.DifferentialExperimentBuilder()
-                        .withSecondaryAccessions(ImmutableList.of("GSE150361", "GSE5454"))
+                        .withSecondaryAccessions(secondaryAccessions)
                         .build();
 
-        // We can’t use URI::getPath because the redirect prefix messes it up :/
         assertThat(subject.get(differentialExperiment))
+                .hasSize(secondaryAccessions.size())
                 .anyMatch(externallyAvailableContent ->
-                        externallyAvailableContent.uri.toString().endsWith("GSE150361"))
+                        externallyAvailableContent.uri.toString().endsWith(secondaryAccessions.get(0)))
                 .anyMatch(externallyAvailableContent ->
-                        externallyAvailableContent.uri.toString().endsWith("GSE5454"))
-                .anyMatch(externallyAvailableContent -> externallyAvailableContent.description.type().equals("icon-geo"))
-                .hasSize(2);
+                        externallyAvailableContent.uri.toString().endsWith(secondaryAccessions.get(1)))
+                .anyMatch(externallyAvailableContent -> externallyAvailableContent.description.type()
+                        .equals(EXPECTED_DESCRIPTION_TYPE));
+    }
+
+    @Test
+    void givenExperimentHasDifferentGEOResources_ThenAvailableResourcesContainsCorrectGEOResourceLinks() {
+        Random rand = new Random();
+
+        final String accessionParamName = "acc=";
+
+        var secondaryAccessions = Stream.generate(() -> rand.nextBoolean() ? "GSE" : "GDS")
+                .limit(20)
+                .map(type -> type + rand.nextInt())
+                .collect(toImmutableList());
+        var linkTypes = Map.ofEntries(
+                entry("GSE", ".*/geo/query/acc.cgi\\?acc="),
+                entry("GDS", ".*/geo/query/acc.cgi\\?acc=")
+        );
+        var experiment = new ExperimentBuilder.BaselineExperimentBuilder()
+                .withSecondaryAccessions(secondaryAccessions)
+                .build();
+
+        var resourceLinks = subject.get(experiment);
+
+        assertThat(resourceLinks).hasSize(secondaryAccessions.size());
+        for (ExternallyAvailableContent resourceLink : resourceLinks) {
+            var link = resourceLink.uri.toString();
+            var accessionPrefixFromLink = link.substring(
+                    link.lastIndexOf(accessionParamName) + accessionParamName.length())
+                    .substring(0, 3);
+            var pathSegmentType = linkTypes.get(accessionPrefixFromLink);
+            var expectedURLRegexp = pathSegmentType + accessionPrefixFromLink + ".*";
+            assertThat(link).matches(expectedURLRegexp);
+            assertThat(resourceLink.description.type()).isEqualTo(EXPECTED_DESCRIPTION_TYPE);
+        }
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeoIT.java
@@ -17,9 +17,9 @@ import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentT
 
 class LinkToGeoIT {
 
-    String EXPECTED_DESCRIPTION_TYPE = "icon-geo";
+    private final String EXPECTED_DESCRIPTION_TYPE = "icon-geo";
 
-    LinkToGeo subject;
+    private LinkToGeo subject;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToGeoIT.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -17,7 +18,8 @@ import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentT
 
 class LinkToGeoIT {
 
-    private final String EXPECTED_DESCRIPTION_TYPE = "icon-geo";
+    private static final String EXPECTED_DESCRIPTION_TYPE = "icon-geo";
+    private static final String GEO_RESOURCE_DESCRIPTION = "GEO: ";
 
     private LinkToGeo subject;
 
@@ -45,18 +47,19 @@ class LinkToGeoIT {
     }
 
     @Test
-    void givenExperimentHasDifferentGEOResources_ThenAvailableResourcesContainsCorrectGEOResourceLinks() {
+    void givenExperimentHasDifferentGEOResources_ThenAvailableResourcesContainsCorrectGEOResourceLinks()
+            throws URISyntaxException {
         Random rand = new Random();
 
         final String accessionParamName = "acc=";
 
         var secondaryAccessions = Stream.generate(() -> rand.nextBoolean() ? "GSE" : "GDS")
                 .limit(20)
-                .map(type -> type + rand.nextInt())
+                .map(type -> type + Math.abs(rand.nextInt()))
                 .collect(toImmutableList());
         var linkTypes = Map.ofEntries(
-                entry("GSE", ".*/geo/query/acc.cgi\\?acc="),
-                entry("GDS", ".*/geo/query/acc.cgi\\?acc=")
+                entry("GSE", "redirect:https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc="),
+                entry("GDS", "redirect:https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=")
         );
         var experiment = new ExperimentBuilder.BaselineExperimentBuilder()
                 .withSecondaryAccessions(secondaryAccessions)
@@ -67,13 +70,15 @@ class LinkToGeoIT {
         assertThat(resourceLinks).hasSize(secondaryAccessions.size());
         for (ExternallyAvailableContent resourceLink : resourceLinks) {
             var link = resourceLink.uri.toString();
-            var accessionPrefixFromLink = link.substring(
-                    link.lastIndexOf(accessionParamName) + accessionParamName.length())
-                    .substring(0, 3);
+            var accessionFromLink = link.substring(
+                    link.lastIndexOf(accessionParamName) + accessionParamName.length());
+            var accessionPrefixFromLink = accessionFromLink.substring(0, 3);
             var pathSegmentType = linkTypes.get(accessionPrefixFromLink);
-            var expectedURLRegexp = pathSegmentType + accessionPrefixFromLink + ".*";
-            assertThat(link).matches(expectedURLRegexp);
-            assertThat(resourceLink.description.type()).isEqualTo(EXPECTED_DESCRIPTION_TYPE);
+            var expectedURL = pathSegmentType + accessionFromLink;
+            ResourceLinkAssertionUtil.assertResourceLink(resourceLink,
+                    expectedURL,
+                    EXPECTED_DESCRIPTION_TYPE,
+                    GEO_RESOURCE_DESCRIPTION + accessionFromLink);
         }
     }
 

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToPrideIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToPrideIT.java
@@ -7,11 +7,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
+import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Random;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static uk.ac.ebi.atlas.model.download.ExternallyAvailableContent.ContentType.SUPPLEMENTARY_INFORMATION;
@@ -29,64 +33,68 @@ class LinkToPrideIT {
         subject = new LinkToPride();
     }
 
-    final String PRIDEURI = "redirect:https://www.ebi.ac.uk/pride/archive/projects/";
-    final String PRIDEDESCRIPTION = "PRIDE Archive: project ";
+    final String PRIDE_URI = "redirect:https://www.ebi.ac.uk/pride/archive/projects/";
+    final String PRIDE_DESCRIPTION = "PRIDE Archive: project ";
 
     @Test
-    void oneLinkAndIconPointAtPride() throws URISyntaxException {
-        var accession = generateRandomPrideExperimentAccession();
-        when(baselineExperimentMock.getSecondaryAccessions()).thenReturn(ImmutableSet.of(accession));
-        assertThat(subject.get(baselineExperimentMock))
-                .hasSize(1)
-                .first()
-                .hasFieldOrPropertyWithValue(
-                        "uri",
-                        new URI(PRIDEURI + accession))
-                .hasFieldOrPropertyWithValue(
-                        "description",
-                        ExternallyAvailableContent.Description.create("icon-pride", PRIDEDESCRIPTION + accession));
+    void givenLinksToExperiment_ThenAvailableResourcesContainsThoseLinks() throws URISyntaxException {
+        var secondaryAccessions = List.of(generateRandomPrideExperimentAccession());
+        var experiment = new ExperimentBuilder.TestExperimentBuilder()
+                .withSecondaryAccessions(secondaryAccessions)
+                .build();
+
+        var resourceLinks = subject.get(experiment);
+
+        for (ExternallyAvailableContent resourceLink : resourceLinks) {
+            assertResourceLink(resourceLink, secondaryAccessions.get(0));
+        }
     }
 
     @Test
-    void multipleLinkAndIconPointAtPride() throws URISyntaxException {
-        var accession1 = generateRandomPrideExperimentAccession();
-        var accession2 = generateRandomPrideExperimentAccession();
-        when(baselineExperimentMock.getSecondaryAccessions()).thenReturn(ImmutableSet.of(accession1, accession2));
-        var result = subject.get(baselineExperimentMock);
+    void givenMultipleLinksToExperiment_ThenAvailableResourcesContainsThoseLinks() throws URISyntaxException {
+        Random rand = new Random();
 
-        assertThat(result).hasSize(2);
+        var secondaryAccessions = rand.ints(20, 0, 9999)
+                .mapToObj(index -> "PXD" + index)
+                .collect(toImmutableList());
 
-        assertThat(result)
-                .element(0)
-                .hasFieldOrPropertyWithValue(
-                        "uri",
-                        new URI(PRIDEURI + accession1))
-                .hasFieldOrPropertyWithValue(
-                        "description",
-                        ExternallyAvailableContent.Description.create("icon-pride", PRIDEDESCRIPTION + accession1));
+        var experiment = new ExperimentBuilder.TestExperimentBuilder()
+                .withSecondaryAccessions(secondaryAccessions)
+                .build();
 
-        assertThat(result)
-                .element(1)
-                .hasFieldOrPropertyWithValue(
-                        "uri",
-                        new URI(PRIDEURI + accession2))
-                .hasFieldOrPropertyWithValue(
-                        "description",
-                        ExternallyAvailableContent.Description.create("icon-pride", PRIDEDESCRIPTION + accession2));
+        var resourceLinks = subject.get(experiment);
+
+        assertThat(resourceLinks).hasSize(secondaryAccessions.size());
+
+        for (ExternallyAvailableContent resourceLink : resourceLinks) {
+            var link = resourceLink.uri.toString();
+            var accessionPrefixFromLink = link.substring(
+                            link.lastIndexOf("/") + 1);
+            assertResourceLink(resourceLink, accessionPrefixFromLink);
+        }
     }
 
-
     @Test
-    void noLinkAndIconPointAtPride() throws URISyntaxException {
+    void whenNoExternalResourceAvailableForExperiment_NoLinksAndIconPointAtPride() {
         when(baselineExperimentMock.getSecondaryAccessions()).thenReturn(ImmutableSet.of());
         assertThat(subject.get(baselineExperimentMock))
                 .hasSize(0);
-
     }
 
     @Test
-    void goesIntoSupplementaryInformationTab() {
+    void whenExternalResourceAvailableToPrideExperiment_thenShowInSupplementaryInformationTab() {
         assertThat(subject.contentType())
                 .isEqualTo(SUPPLEMENTARY_INFORMATION);
+    }
+
+    private void assertResourceLink(ExternallyAvailableContent resourceLink, String accessionPrefixFromLink) throws URISyntaxException {
+        assertThat(resourceLink)
+                .hasFieldOrPropertyWithValue(
+                        "uri",
+                        new URI(PRIDE_URI + accessionPrefixFromLink))
+                .hasFieldOrPropertyWithValue(
+                        "description",
+                        ExternallyAvailableContent.Description.create(
+                                "icon-pride", PRIDE_DESCRIPTION + accessionPrefixFromLink));
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToPrideIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/LinkToPrideIT.java
@@ -10,7 +10,6 @@ import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 import uk.ac.ebi.atlas.model.experiment.ExperimentBuilder;
 import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Random;
@@ -33,8 +32,9 @@ class LinkToPrideIT {
         subject = new LinkToPride();
     }
 
-    final String PRIDE_URI = "redirect:https://www.ebi.ac.uk/pride/archive/projects/";
-    final String PRIDE_DESCRIPTION = "PRIDE Archive: project ";
+    private static final String PRIDE_URI = "redirect:https://www.ebi.ac.uk/pride/archive/projects/";
+    private static final String EXPECTED_DESCRIPTION_TYPE = "icon-pride";
+    private static final String PRIDE_DESCRIPTION = "PRIDE Archive: project ";
 
     @Test
     void givenLinksToExperiment_ThenAvailableResourcesContainsThoseLinks() throws URISyntaxException {
@@ -45,8 +45,12 @@ class LinkToPrideIT {
 
         var resourceLinks = subject.get(experiment);
 
+        final String secondaryAccession = secondaryAccessions.get(0);
         for (ExternallyAvailableContent resourceLink : resourceLinks) {
-            assertResourceLink(resourceLink, secondaryAccessions.get(0));
+            ResourceLinkAssertionUtil.assertResourceLink(resourceLink,
+                    PRIDE_URI + secondaryAccession,
+                    EXPECTED_DESCRIPTION_TYPE,
+                    PRIDE_DESCRIPTION + secondaryAccession);
         }
     }
 
@@ -70,7 +74,10 @@ class LinkToPrideIT {
             var link = resourceLink.uri.toString();
             var accessionPrefixFromLink = link.substring(
                             link.lastIndexOf("/") + 1);
-            assertResourceLink(resourceLink, accessionPrefixFromLink);
+            ResourceLinkAssertionUtil.assertResourceLink(resourceLink,
+                    PRIDE_URI + accessionPrefixFromLink,
+                    EXPECTED_DESCRIPTION_TYPE,
+                    PRIDE_DESCRIPTION + accessionPrefixFromLink);
         }
     }
 
@@ -85,16 +92,5 @@ class LinkToPrideIT {
     void whenExternalResourceAvailableToPrideExperiment_thenShowInSupplementaryInformationTab() {
         assertThat(subject.contentType())
                 .isEqualTo(SUPPLEMENTARY_INFORMATION);
-    }
-
-    private void assertResourceLink(ExternallyAvailableContent resourceLink, String accessionPrefixFromLink) throws URISyntaxException {
-        assertThat(resourceLink)
-                .hasFieldOrPropertyWithValue(
-                        "uri",
-                        new URI(PRIDE_URI + accessionPrefixFromLink))
-                .hasFieldOrPropertyWithValue(
-                        "description",
-                        ExternallyAvailableContent.Description.create(
-                                "icon-pride", PRIDE_DESCRIPTION + accessionPrefixFromLink));
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/link/ResourceLinkAssertionUtil.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/link/ResourceLinkAssertionUtil.java
@@ -1,0 +1,24 @@
+package uk.ac.ebi.atlas.experimentpage.link;
+
+import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResourceLinkAssertionUtil {
+
+    public static void assertResourceLink(ExternallyAvailableContent resourceLink,
+                                          String uri,
+                                          String descriptionType,
+                                          String description) throws URISyntaxException {
+        assertThat(resourceLink)
+                .hasFieldOrPropertyWithValue(
+                        "uri",
+                        new URI(uri))
+                .hasFieldOrPropertyWithValue(
+                        "description",
+                        ExternallyAvailableContent.Description.create(descriptionType, description));
+    }
+}


### PR DESCRIPTION
This is a complete refactor of experiment's external resource handling.

- There was an error regarding to EGA resource links. Every link's URI contained /studies even if that resource was a dataset.
- Also some archive's base resource link has been updated.

Accompanying PR in `atlas-web-bulk`: [Refactor experiment's external resource handling #214](https://github.com/ebi-gene-expression-group/atlas-web-bulk/pull/214)

Manual checks

- [ ] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
