### PR TITLE
Add exists and notExists methods SolrQueryBuilder

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.stream.Collectors.joining;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createDoubleBoundRangeQuery;
+import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createFieldExistQuery;
+import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createFieldNotExistQuery;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createLowerBoundRangeQuery;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createNegativeFilterQuery;
 import static uk.ac.ebi.atlas.solr.cloud.search.SolrQueryUtils.createOrBooleanQuery;
@@ -119,6 +121,16 @@ public class SolrQueryBuilder<T extends CollectionProxy<?>> {
 
     public <U extends SchemaField<T>> SolrQueryBuilder<T> addNegativeFilterFieldByTerm(U field, Collection<String> values) {
         fqClausesBuilder.add(createNegativeFilterQuery(field,values,normalize));
+        return this;
+    }
+
+    public <U extends SchemaField<T>> SolrQueryBuilder<T> exists(U fieldNameToExist) {
+        qClausesBuilder.add(createFieldExistQuery(fieldNameToExist));
+        return this;
+    }
+
+    public <U extends SchemaField<T>> SolrQueryBuilder<T> notExists(U fieldNameToNotExist) {
+        qClausesBuilder.add(createFieldNotExistQuery(fieldNameToNotExist));
         return this;
     }
 

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilder.java
@@ -124,13 +124,13 @@ public class SolrQueryBuilder<T extends CollectionProxy<?>> {
         return this;
     }
 
-    public <U extends SchemaField<T>> SolrQueryBuilder<T> exists(U fieldNameToExist) {
-        qClausesBuilder.add(createFieldExistQuery(fieldNameToExist));
+    public <U extends SchemaField<T>> SolrQueryBuilder<T> exists(U field) {
+        qClausesBuilder.add(createFieldExistQuery(field));
         return this;
     }
 
-    public <U extends SchemaField<T>> SolrQueryBuilder<T> notExists(U fieldNameToNotExist) {
-        qClausesBuilder.add(createFieldNotExistQuery(fieldNameToNotExist));
+    public <U extends SchemaField<T>> SolrQueryBuilder<T> notExists(U field) {
+        qClausesBuilder.add(createFieldNotExistQuery(field));
         return this;
     }
 

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryUtils.java
@@ -19,6 +19,8 @@ public class SolrQueryUtils {
     // can be done for those fields. My educated guess is that the term(s) query parser improves performance when it’s
     // used on an analyzed field because it avoids that processing step.
     private static final String STANDARD_QUERY_PARSER_FIELD_QUERY_TEMPLATE = "%s:(%s)";
+    private static final String STANDARD_QUERY_PARSER_FIELD_EXIST_QUERY_TEMPLATE = "%s:*";
+    private static final String STANDARD_QUERY_PARSER_FIELD_NOT_EXIST_QUERY_TEMPLATE = "!%s:*";
     private static final String STANDARD_QUERY_PARSER_EXCLUDE_FIELD_QUERY_TEMPLATE = "!%s:*";
     private static final String STANDARD_QUERY_PARSER_LOWER_BOUND_RANGE_QUERY_TEMPLATE = "%s:[%s TO *]";
     private static final String STANDARD_QUERY_PARSER_UPPER_BOUND_RANGE_QUERY_TEMPLATE = "%s:[* TO %s]";
@@ -29,11 +31,11 @@ public class SolrQueryUtils {
         return "\"" + escapeQueryChars(str.trim()) + "\"";
     }
 
-    public static String createOrBooleanQuery(SchemaField field, Collection<String> values) {
+    public static String createOrBooleanQuery(SchemaField<?> field, Collection<String> values) {
         return createOrBooleanQuery(field, values, true);
     }
 
-    public static String createNegativeFilterQuery(SchemaField field, Collection<String> values, boolean normalize) {
+    public static String createNegativeFilterQuery(SchemaField<?> field, Collection<String> values, boolean normalize) {
         return String.format(
                         STANDARD_QUERY_PARSER_NEGATIVE_QUERY_FILTER_QUERY_TEMPLATE,
                         field.name(),
@@ -44,7 +46,7 @@ public class SolrQueryUtils {
                                 .collect(joining(" OR ")));
     }
 
-    public static String createOrBooleanQuery(SchemaField field, Collection<String> values, boolean normalize) {
+    public static String createOrBooleanQuery(SchemaField<?> field, Collection<String> values, boolean normalize) {
         return values.stream().anyMatch(StringUtils::isNotBlank) ?
                 String.format(
                         STANDARD_QUERY_PARSER_FIELD_QUERY_TEMPLATE,
@@ -57,25 +59,33 @@ public class SolrQueryUtils {
                 String.format(STANDARD_QUERY_PARSER_EXCLUDE_FIELD_QUERY_TEMPLATE, field.name());
     }
 
-    public static String createLowerBoundRangeQuery(SchemaField field, double min) {
+    public static String createLowerBoundRangeQuery(SchemaField<?> field, double min) {
         return String.format(
                 STANDARD_QUERY_PARSER_LOWER_BOUND_RANGE_QUERY_TEMPLATE,
                 field.name(),
-                Double.toString(min));
+                min);
     }
 
-    public static String createUpperBoundRangeQuery(SchemaField field, double max) {
+    public static String createUpperBoundRangeQuery(SchemaField<?> field, double max) {
         return String.format(
                 STANDARD_QUERY_PARSER_UPPER_BOUND_RANGE_QUERY_TEMPLATE,
                 field.name(),
-                Double.toString(max));
+                max);
     }
 
-    public static String createDoubleBoundRangeQuery(SchemaField field, double min, double max) {
+    public static String createDoubleBoundRangeQuery(SchemaField<?> field, double min, double max) {
         return String.format(
                 STANDARD_QUERY_PARSER_DOUBLE_BOUND_RANGE_QUERY_TEMPLATE,
                 field.name(),
-                Double.toString(min),
-                Double.toString(max));
+                min,
+                max);
+    }
+
+    public static String createFieldExistQuery(SchemaField<?> fieldNameToExist) {
+        return String.format(STANDARD_QUERY_PARSER_FIELD_EXIST_QUERY_TEMPLATE, fieldNameToExist.name());
+    }
+
+    public static String createFieldNotExistQuery(SchemaField<?> fieldNameToExist) {
+        return String.format(STANDARD_QUERY_PARSER_FIELD_NOT_EXIST_QUERY_TEMPLATE, fieldNameToExist.name());
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryUtils.java
+++ b/src/main/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryUtils.java
@@ -81,11 +81,11 @@ public class SolrQueryUtils {
                 max);
     }
 
-    public static String createFieldExistQuery(SchemaField<?> fieldNameToExist) {
-        return String.format(STANDARD_QUERY_PARSER_FIELD_EXIST_QUERY_TEMPLATE, fieldNameToExist.name());
+    public static String createFieldExistQuery(SchemaField<?> field) {
+        return String.format(STANDARD_QUERY_PARSER_FIELD_EXIST_QUERY_TEMPLATE, field.name());
     }
 
-    public static String createFieldNotExistQuery(SchemaField<?> fieldNameToExist) {
-        return String.format(STANDARD_QUERY_PARSER_FIELD_NOT_EXIST_QUERY_TEMPLATE, fieldNameToExist.name());
+    public static String createFieldNotExistQuery(SchemaField<?> field) {
+        return String.format(STANDARD_QUERY_PARSER_FIELD_NOT_EXIST_QUERY_TEMPLATE, field.name());
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilderTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/solr/cloud/search/SolrQueryBuilderTest.java
@@ -173,4 +173,30 @@ class SolrQueryBuilderTest {
 
         assertThat(solrQuery.getQuery()).isEqualTo(FIELD1.name() + ":(\"\\" + fieldValue + "\")");
     }
+
+    @Test
+    void whenAddedFieldForExistence_thenBuiltQueryContainsFieldForExistence() {
+        var fieldNameToExist = new DummySchemaField("fieldToExists");
+        var expectedQuery = fieldNameToExist.name() + ":*";
+
+        SolrQuery solrQuery =
+            new SolrQueryBuilder<>()
+                .exists(fieldNameToExist)
+                .build();
+
+        assertThat(solrQuery.getQuery()).isEqualTo(expectedQuery);
+    }
+
+    @Test
+    void whenAddedFieldForNonExistence_thenBuiltQueryContainsFieldForNonExistence() {
+        var fieldNameToExist = new DummySchemaField("fieldToNotExists");
+        var expectedQuery = "!" + fieldNameToExist.name() + ":*";
+
+        SolrQuery solrQuery =
+            new SolrQueryBuilder<>()
+                .notExists(fieldNameToExist)
+                .build();
+
+        assertThat(solrQuery.getQuery()).isEqualTo(expectedQuery);
+    }
 }


### PR DESCRIPTION
This change adds 2 methods to the `SolrQueryBuilder` class.
- exists(schemaField) : add a query clause as a filter to the query builder and the result contains only Solr documents where the given field exists.
- notExists(schemaField) : add a query clause as a filter to the query builder and the result contains only Solr documents where the given field does not exist.


Manual checks

- [ ] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
