### PR TITLE
[Chore] #520 - Refactor HtmlExceptionHandlingController to simplify exception handling

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/controllers/HtmlExceptionHandlingController.java
+++ b/src/main/java/uk/ac/ebi/atlas/controllers/HtmlExceptionHandlingController.java
@@ -1,63 +1,49 @@
 package uk.ac.ebi.atlas.controllers;
 
 import com.google.common.base.Joiner;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
-public abstract class HtmlExceptionHandlingController {
+@ControllerAdvice
+class HtmlExceptionHandlingController {
     private static final Logger LOGGER = LoggerFactory.getLogger(HtmlExceptionHandlingController.class);
 
-    @Autowired
-    protected Environment env;
-
-    @ExceptionHandler(value = {ResourceNotFoundException.class})
-    @ResponseStatus(value = HttpStatus.NOT_FOUND)
-    public ModelAndView handleResourceNotFoundException(Exception e) {
-        ModelAndView mav = new ModelAndView("error-page");
-        mav.addObject("exceptionMessage", e.getMessage());
-        mav.addObject("statusCode", HttpStatus.NOT_FOUND.value());
-        addPageTitle(mav);
-        return mav;
-    }
-
-    @ExceptionHandler(value = {BioentityNotFoundException.class})
-    @ResponseStatus(value = HttpStatus.NOT_FOUND)
-    public ModelAndView handleBioentityNotFoundException(Exception e) {
-        ModelAndView mav = new ModelAndView("error-page");
-        mav.addObject("exceptionMessage", e.getMessage());
-        mav.addObject("statusCode", HttpStatus.NOT_FOUND.value());
-        addPageTitle(mav);
-        return mav;
+    @ExceptionHandler({
+        ResourceNotFoundException.class,
+        BioentityNotFoundException.class,
+        NoHandlerFoundException.class
+    })
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ModelAndView handleNotFoundExceptions(Exception e) {
+        return handleException(e, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(value = {UnparseableSemanticQueryException.class})
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     public ModelAndView handleBadJsonException(Exception e) {
-        ModelAndView mav = new ModelAndView("error-page");
-        mav.addObject("exceptionMessage", e.getMessage());
-        mav.addObject("statusCode", HttpStatus.BAD_REQUEST.value());
-        addPageTitle(mav);
-        return mav;
+        return handleException(e, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(value = {Exception.class})
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     public ModelAndView handleExceptionFallback(Exception e) {
         LOGGER.error("{} - {}", e.getMessage(), Joiner.on("\n\t").join(e.getStackTrace()));
-        ModelAndView mav = new ModelAndView("error-page");
-        mav.addObject("exceptionMessage", e.getMessage());
-        mav.addObject("statusCode", HttpStatus.BAD_REQUEST.value());
-        addPageTitle(mav);
-        return mav;
+        return handleException(e, HttpStatus.BAD_REQUEST);
     }
 
-    private void addPageTitle(ModelAndView mav) {
-        mav.addObject("title", "Help");
+    private @NotNull ModelAndView handleException(Exception e, HttpStatus status) {
+        ModelAndView mav = new ModelAndView("error-page");
+        mav.addObject("exceptionMessage", e.getMessage());
+        mav.addObject("statusCode", status.value());
+        mav.addObject("title", "Error: " + status.value()); // Added more informative title
+
+        return mav;
     }
 }


### PR DESCRIPTION
Consolidated exception handlers and introduced a single utility method to reduce code duplication. Replaced class annotation with @ControllerAdvice for global exception handling. Removed unnecessary dependencies and improved response title formatting for better clarity.

Manual checks

- [ ] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
