### PR TITLE
Add a getter function for cluster tsv file

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/resource/DataFileHub.java
+++ b/src/main/java/uk/ac/ebi/atlas/resource/DataFileHub.java
@@ -505,7 +505,11 @@ public class DataFileHub {
                     experimentAccession);
         }
 
-//        public AtlasResource<MatrixMarketReader> dataFile(ExpressionUnit.Absolute.Rna unit) {
+        public AtlasResource<TsvStreamer> getClustersTsv() {
+            return clustersTsv;
+        }
+
+        //        public AtlasResource<MatrixMarketReader> dataFile(ExpressionUnit.Absolute.Rna unit) {
 //            switch(unit) {
 //                case TPM:
 //                    return tpms;


### PR DESCRIPTION
It comes with atlas-web-single-cell PR https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/540
Manual checks

- [ ] This branch is passing the CI tests as part of a pull request in the atlas-web-bulk or atlas-web-scxa repos and I have indicated that PR here. 
